### PR TITLE
feat: delegate evidence tools to ChittyStorage via SVC_STORAGE

### DIFF
--- a/scripts/deploy-secrets-connect.sh
+++ b/scripts/deploy-secrets-connect.sh
@@ -158,7 +158,16 @@ deploy_secret "CHITTY_DNA_TOKEN"        "$VAULT_SERVICES" "agd7l6vbolyn4rtoxrafm
 deploy_secret "CHITTY_VERIFY_TOKEN"     "$VAULT_SERVICES" "sozaaemylfw3krabpyueqwmytq" "credential"
 deploy_secret "CHITTY_SERV_TOKEN"       "$VAULT_SERVICES" "sozaaemylfw3krabpyueqwmytq" "credential"
 deploy_secret "CHITTY_PROOF_TOKEN"      "$VAULT_SERVICES" "sozaaemylfw3krabpyueqwmytq" "credential"
-deploy_secret "CHITTY_TASK_TOKEN"       "$VAULT_SERVICES" "sozaaemylfw3krabpyueqwmytq" "credential"
+# CHITTY_TASK_TOKEN — auth token chittyconnect sends to tasks.chitty.cc (chittyagent-tasks)
+# Source: CHITTY_API_GATEWAY_SERVICE_TOKEN (ChittyGateway API Token, item 6pnxym6ke46wote7qwexaakni4)
+# NOTE: the chittyconnect-prod item (sozaaemylfw3krabpyueqwmytq) credential field is empty.
+# chittyagent-tasks validates against CHITTY_AUTH_SERVICE_TOKEN which was provisioned via
+# set-worker-secret.yml using the GitHub repo secret CHITTY_API_GATEWAY_SERVICE_TOKEN.
+# Until vault item 6pnxym6ke46wote7qwexaakni4 is populated, this line will fail. The secret
+# is currently set directly in Cloudflare. To re-provision:
+#   op read "op://ChittyOS/ChittyGateway API Token/credential" | \
+#     wrangler secret put CHITTY_TASK_TOKEN --env production
+deploy_secret "CHITTY_TASK_TOKEN"       "$VAULT_SERVICES" "6pnxym6ke46wote7qwexaakni4" "credential"
 deploy_secret "CHITTY_TRUST_TOKEN"      "$VAULT_SERVICES" "sozaaemylfw3krabpyueqwmytq" "credential"
 
 # GitHub App ID — from GitHub App PK item (Core vault)

--- a/src/api/routes/credentials.js
+++ b/src/api/routes/credentials.js
@@ -670,6 +670,54 @@ credentialsRoutes.get("/:vault/:item/:field", async (c) => {
 });
 
 /**
+
+/**
+ * PUT /api/credentials/:vault/:item/:field
+ *
+ * Store or update a credential in 1Password via ChittyConnect.
+ * Source of truth: value → 1Password → cached in KV.
+ *
+ * Body: { "value": "secret", "notes": "optional context" }
+ */
+credentialsRoutes.put("/:vault/:item/:field", async (c) => {
+  try {
+    const vault = c.req.param("vault");
+    const item = c.req.param("item");
+    const field = c.req.param("field");
+
+    const validVaults = ["infrastructure", "services", "integrations", "emergency"];
+    if (!validVaults.includes(vault)) {
+      return c.json({ success: false, error: { code: "INVALID_VAULT", message: `Invalid vault: ${vault}` } }, 400);
+    }
+
+    const body = await c.req.json();
+    if (!body.value) {
+      return c.json({ success: false, error: { code: "MISSING_VALUE", message: "Request body must include value" } }, 400);
+    }
+
+    const apiKeyMeta = c.get("apiKey") || {};
+    const requestingService = apiKeyMeta.service || apiKeyMeta.name || "unknown";
+
+    console.log(`[Credentials] Storing ${vault}/${item}/${field} (by ${requestingService})`);
+
+    const { OnePasswordConnectClient } = await import("../../services/1password-connect-client.js");
+    const client = new OnePasswordConnectClient(c.env);
+    const result = await client.put(`${vault}/${item}/${field}`, body.value, { notes: body.notes });
+
+    try {
+      await c.env.DB.prepare(
+        `INSERT INTO credential_provisions (type, service, purpose, requesting_service, created_at) VALUES (1password_store, ?, ?, ?, datetime(now))`
+      ).bind(item, field, requestingService).run();
+    } catch (dbErr) {
+      console.warn("[Credentials] Audit log failed:", dbErr.message);
+    }
+
+    return c.json({ success: true, ...result, metadata: { vault, item, field, timestamp: new Date().toISOString() } }, result.action === "created" ? 201 : 200);
+  } catch (error) {
+    console.error("[Credentials] Store error:", error);
+    return c.json({ success: false, error: { code: "STORE_FAILED", message: error.message } }, 500);
+  }
+});
  * GET /api/credentials/health
  *
  * Check credential provisioning service health

--- a/src/mcp/tool-dispatcher.js
+++ b/src/mcp/tool-dispatcher.js
@@ -854,134 +854,50 @@ export async function dispatchToolCall(name, args = {}, env, options = {}) {
     }
 
     // ── Evidence AI Search tools ────────────────────────────────────
+    // ── Evidence tools — delegated to ChittyStorage (search/retrieve/ingest) ──
     else if (name === "chitty_evidence_search") {
-      const accountId = env.CHITTYOS_ACCOUNT_ID;
-      if (!accountId) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "AI Search not configured: CHITTYOS_ACCOUNT_ID not set.",
-            },
-          ],
-          isError: true,
-        };
+      if (!env.SVC_STORAGE) {
+        return { content: [{ type: "text", text: "ChittyStorage not configured (SVC_STORAGE binding missing)" }], isError: true };
       }
-      const aiSearchToken = env.AI_SEARCH_TOKEN;
-      if (!aiSearchToken) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "AI Search not configured: AI_SEARCH_TOKEN secret not set.",
-            },
-          ],
-          isError: true,
-        };
+      const params = new URLSearchParams({ q: args.query || "", limit: String(args.max_num_results || 10) });
+      if (args.entity_slug) params.set("entity", args.entity_slug);
+      const response = await env.SVC_STORAGE.fetch(`https://internal/api/docs?${params}`);
+      const data = await response.json();
+      if (!data.docs || !data.docs.length) {
+        return { content: [{ type: "text", text: "No matching documents found." }] };
       }
-      const response = await fetch(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai-search/instances/chittyevidence-search/search`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${aiSearchToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            messages: [{ role: "user", content: args.query }],
-            max_num_results: 10,
-          }),
-        },
-      );
-      const text = await response.text();
-      let data;
-      try {
-        data = JSON.parse(text);
-      } catch {
-        data = null;
-      }
-      if (!data || !data.success) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `AI Search error (${response.status}): ${(text || "").slice(0, 300)}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-      const chunks = data.result?.chunks || [];
-      const formatted = chunks
-        .slice(0, 5)
-        .map((d) => {
-          const fname = d.item?.key || d.filename || "unknown";
-          const score = (d.score || 0).toFixed(3);
-          const snippet = (d.text || "").slice(0, 200).replace(/\n/g, " ");
-          return `[${score}] ${fname}\n  ${snippet}`;
-        })
-        .join("\n\n");
-      return {
-        content: [
-          { type: "text", text: formatted || "No matching documents found." },
-        ],
-      };
+      const formatted = data.docs.slice(0, 10).map((d) => {
+        const tags = d.tags || {};
+        const entity = tags.primary_entity || "unlinked";
+        const docType = tags.doc_type || "unclassified";
+        return `[${entity}/${docType}] ${d.filename}\n  hash: ${d.content_hash}\n  tier: ${d.processing_tier} | created: ${d.created_at}`;
+      }).join("\n\n");
+      return { content: [{ type: "text", text: formatted }] };
     } else if (name === "chitty_evidence_retrieve") {
-      const accountId = env.CHITTYOS_ACCOUNT_ID;
-      if (!accountId) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "AI Search not configured: CHITTYOS_ACCOUNT_ID not set.",
-            },
-          ],
-          isError: true,
-        };
+      if (!env.SVC_STORAGE) {
+        return { content: [{ type: "text", text: "ChittyStorage not configured (SVC_STORAGE binding missing)" }], isError: true };
       }
-      const aiSearchToken = env.AI_SEARCH_TOKEN;
-      if (!aiSearchToken) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "AI Search not configured: AI_SEARCH_TOKEN secret not set.",
-            },
-          ],
-          isError: true,
-        };
+      const hash = args.content_hash || args.evidence_id || args.query;
+      if (!hash) {
+        return { content: [{ type: "text", text: "Provide content_hash, evidence_id, or query to retrieve." }], isError: true };
       }
-      const response = await fetch(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai-search/instances/chittyevidence-search/search`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${aiSearchToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            messages: [{ role: "user", content: args.query }],
-            max_num_results: args.max_num_results || 10,
-          }),
-        },
-      );
-      const text = await response.text();
-      try {
-        result = JSON.parse(text);
-      } catch {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `AI Search retrieve error (${response.status}): ${(text || "").slice(0, 300)}`,
-            },
-          ],
-          isError: true,
-        };
+      const response = await env.SVC_STORAGE.fetch(`https://internal/api/docs?q=${encodeURIComponent(hash)}&limit=1`);
+      const data = await response.json();
+      if (!data.docs?.length) {
+        return { content: [{ type: "text", text: `Document not found: ${hash}` }], isError: true };
       }
+      const doc = data.docs[0];
+      result = {
+        chitty_id: doc.chitty_id,
+        content_hash: doc.content_hash,
+        filename: doc.filename,
+        processing_tier: doc.processing_tier,
+        tags: doc.tags || {},
+        entities: doc.entities || [],
+        file_url: `https://storage.chitty.cc/api/files/${doc.content_hash}`,
+      };
     }
 
-    // ── Evidence CRUD tools (ingest/verify) ─────────────────────────
     else if (name.startsWith("chitty_evidence_")) {
       const action = name.replace("chitty_evidence_", "");
       const endpoint =

--- a/src/services/1password-connect-client.js
+++ b/src/services/1password-connect-client.js
@@ -541,3 +541,68 @@ export class OnePasswordConnectClient {
 }
 
 export default OnePasswordConnectClient;
+
+/**
+ * Store a credential in 1Password via Connect API.
+ * Creates a new item or updates an existing field.
+ *
+ * @param {string} credentialPath - "vault/item/field"
+ * @param {string} value - Credential value
+ * @param {object} [options]
+ * @param {string} [options.notes] - Item notes
+ * @returns {Promise<{stored: boolean, action: string, item: string}>}
+ */
+OnePasswordConnectClient.prototype.put = async function (credentialPath, value, options = {}) {
+  const parsed = this.parseCredentialPath(credentialPath);
+  if (!parsed) throw new Error(`Invalid credential path: ${credentialPath}`);
+  if (!this.connectUrl || !this.connectToken) throw new Error("1Password Connect not configured");
+
+  const headers = { Authorization: `Bearer ${this.connectToken}`, "Content-Type": "application/json" };
+
+  // List items in vault
+  const itemsResp = await fetch(`${this.connectUrl}/v1/vaults/${parsed.vaultId}/items`, { headers });
+  if (!itemsResp.ok) throw new Error(`Failed to list items: ${itemsResp.status}`);
+  const items = await itemsResp.json();
+  const existing = items.find(i => i.title.toLowerCase() === parsed.item.toLowerCase());
+
+  if (existing) {
+    // Update existing item
+    const detailResp = await fetch(`${this.connectUrl}/v1/vaults/${parsed.vaultId}/items/${existing.id}`, { headers });
+    if (!detailResp.ok) throw new Error(`Failed to get item: ${detailResp.status}`);
+    const itemDetails = await detailResp.json();
+
+    let fieldFound = false;
+    for (const f of itemDetails.fields || []) {
+      if (f.label?.toLowerCase() === parsed.field.toLowerCase()) { f.value = value; fieldFound = true; break; }
+    }
+    if (!fieldFound) {
+      itemDetails.fields = itemDetails.fields || [];
+      itemDetails.fields.push({ id: parsed.field, type: "CONCEALED", label: parsed.field, value });
+    }
+    if (options.notes) {
+      const nf = itemDetails.fields.find(f => f.purpose === "NOTES");
+      if (nf) nf.value = options.notes;
+    }
+
+    const updateResp = await fetch(`${this.connectUrl}/v1/vaults/${parsed.vaultId}/items/${existing.id}`, {
+      method: "PUT", headers, body: JSON.stringify(itemDetails),
+    });
+    if (!updateResp.ok) { const err = await updateResp.text(); throw new Error(`Update failed: ${updateResp.status} ${err}`); }
+    await this.invalidateCache(credentialPath);
+    return { stored: true, action: "updated", item: parsed.item };
+  } else {
+    // Create new item
+    const newItem = {
+      vaultId: parsed.vaultId, title: parsed.item, category: "API_CREDENTIAL",
+      fields: [
+        { id: "notesPlain", type: "STRING", purpose: "NOTES", label: "notesPlain", value: options.notes || `Stored via ChittyConnect ${new Date().toISOString()}` },
+        { id: parsed.field, type: "CONCEALED", label: parsed.field, value },
+      ],
+    };
+    const createResp = await fetch(`${this.connectUrl}/v1/vaults/${parsed.vaultId}/items`, {
+      method: "POST", headers, body: JSON.stringify(newItem),
+    });
+    if (!createResp.ok) { const err = await createResp.text(); throw new Error(`Create failed: ${createResp.status} ${err}`); }
+    return { stored: true, action: "created", item: parsed.item };
+  }
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -151,6 +151,8 @@
         { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
       ],
+        { "binding": "SVC_STORAGE", "service": "chittystorage" }
+      ]
     },
 
     // ════════════════════════════════════════════════════════════════
@@ -240,6 +242,8 @@
         { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
       ],
+        { "binding": "SVC_STORAGE", "service": "chittystorage" }
+      ]
     },
 
     // ════════════════════════════════════════════════════════════════
@@ -333,6 +337,8 @@
         { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
       ],
+        { "binding": "SVC_STORAGE", "service": "chittystorage" }
+      ]
     }
   }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,6 +36,31 @@
   ],
 
   // ──────────────────────────────────────────────────────────────────
+  // CLOUDFLARE SECRETS STORE — shared secrets across workers
+  // Store: default_secrets_store (e914522471964c3c8cf1e601770edcc3)
+  // Top-level binding — inherited by all environments
+  // ──────────────────────────────────────────────────────────────────
+  "secrets_store_secrets": [
+    // Mercury API tokens (7 orgs)
+    { "binding": "MERCURY_TOKEN_ARIBIA_LLC", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_ARIBIA_LLC" },
+    { "binding": "MERCURY_TOKEN_ARIBIA_LLC_CITY_STUDIO", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_ARIBIA_LLC_CITY_STUDIO" },
+    { "binding": "MERCURY_TOKEN_ARIBIA_LLC_APT_ARLENE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_ARIBIA_LLC_APT_ARLENE" },
+    { "binding": "MERCURY_TOKEN_CHICAGO_FURNISHED_CONDOS", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_CHICAGO_FURNISHED_CONDOS" },
+    { "binding": "MERCURY_TOKEN_IT_CAN_BE_LLC", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_IT_CAN_BE_LLC" },
+    { "binding": "MERCURY_TOKEN_CHITTY_SERVICES", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_CHITTY_SERVICES" },
+    { "binding": "MERCURY_TOKEN_JEAN_ARLENE_VENTURING", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_TOKEN_JEAN_ARLENE_VENTURING" },
+    // MCP token
+    { "binding": "CH1TTY_MCP_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "ch1tty_mcp_token" },
+    // CF Access service tokens (client_id + secret for each consumer)
+    { "binding": "CF_ACCESS_CLIENT_ID_CHITTYCOMMAND", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_ID_CHITTYCOMMAND" },
+    { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYCOMMAND", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYCOMMAND" },
+    { "binding": "CF_ACCESS_CLIENT_ID_CHITTYAGENT", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_ID_CHITTYAGENT" },
+    { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYAGENT", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYAGENT" },
+    { "binding": "CF_ACCESS_CLIENT_ID_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_ID_CHITTYFINANCE" },
+    { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE" }
+  ],
+
+  // ──────────────────────────────────────────────────────────────────
   // ENVIRONMENTS — one worker, three declared environments
   // Each env explicitly declares all resource bindings it needs.
   // ──────────────────────────────────────────────────────────────────

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -57,7 +57,11 @@
     { "binding": "CF_ACCESS_CLIENT_ID_CHITTYAGENT", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_ID_CHITTYAGENT" },
     { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYAGENT", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYAGENT" },
     { "binding": "CF_ACCESS_CLIENT_ID_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_ID_CHITTYFINANCE" },
-    { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE" }
+    { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE" },
+    // Mercury OIDC (CF Access SaaS app — programmatic token exchange for write operations)
+    { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
+    { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
+    { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" }
   ],
 
   // ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add SVC_STORAGE service binding to chittystorage worker
- chitty_evidence_search → ChittyStorage /api/docs (Neon enriched)
- chitty_evidence_retrieve → ChittyStorage /api/docs (with file_url)
- Keeps ingest/verify on legacy SVC_EVIDENCE path

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential storage and update functionality for secure credential management.

* **Chores**
  * Updated service bindings and secret store configuration across all environments.
  * Optimized evidence search and retrieval processes to use internal storage services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->