### PR TITLE
charter: Add Neon Auth user/session ownership model

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,7 +2,7 @@
 uri: chittycanon://docs/ops/policy/chittyconnect-charter
 namespace: chittycanon://docs/ops
 type: policy
-version: 1.0.0
+version: 1.1.0
 status: CERTIFIED
 registered_with: chittycanon://core/services/canon
 title: "ChittyConnect Charter"
@@ -36,6 +36,9 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 - ChittyID minting coordination
 - Legal case management via ChittyCases
 - Evidence ingestion via ChittyEvidence
+- User identity and profile management via `neon_auth.user` and `neon_auth.account` on ChittyOS-Core
+- User session management via `neon_auth.session` (when stateful sessions required)
+- Organization/membership management via `neon_auth.organization`, `neon_auth.member`
 
 ### IS NOT Responsible For
 - Direct identity generation (ChittyID)
@@ -78,6 +81,30 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 | External | OpenAI API | Chat completions |
 | External | Google Calendar | Event management |
 | External | Neon Database | SQL queries |
+
+## Neon Auth Ownership
+
+ChittyConnect is the **canonical owner of user identity and session data** within the Neon Auth schema on ChittyOS-Core (`neon_auth` schema, Neon project `restless-grass-40598426`).
+
+### Schema Ownership Split
+
+| `neon_auth` Table | Owner | Rationale |
+|-------------------|-------|-----------|
+| `user`, `account`, `verification` | **ChittyConnect** | User profiles and credentials — per this charter's scope |
+| `session` | **ChittyConnect** | User session management |
+| `organization`, `member`, `invitation` | **ChittyConnect** | Multi-tenant org membership |
+| `jwks` | **ChittyAuth** | JWT signing keys — per ChittyAuth charter scope |
+| `project_config` | **ChittyAuth** | JWKS URL, issuer configuration |
+
+### User Identity Flow
+
+1. **ChittyID** mints the canonical identity (DID format `VV-G-LLL-SSSS-T-YM-C-X`)
+2. **ChittyConnect** writes the user profile to `neon_auth.user` (linked via ChittyID)
+3. **ChittyAuth** signs JWTs with keys from `neon_auth.jwks`, embedding the ChittyID as a claim
+4. **Downstream services** validate JWTs against ChittyAuth's JWKS and use RLS policies referencing `auth.jwt() ->> 'chitty_id'` for per-user data scoping
+
+### Migration Note (2026-04)
+The `neon_auth.user` table on ChittyOS-Core currently has 0 rows. ChittyAuth's existing user data lives in `public.users` (2 rows) and `public.identities` (73 rows). ChittyConnect will migrate user profile data to `neon_auth.user` as part of the Neon Auth unification initiative. See companion amendment: [chittyfoundation/chittyauth#4](https://github.com/chittyfoundation/chittyauth/pull/4).
 
 ## API Contract
 
@@ -186,4 +213,4 @@ This charter is part of a synchronized documentation triad. Changes to shared fi
 - [x] GitHub App webhook verified
 
 ---
-*Charter Version: 1.0.0 | Last Updated: 2026-02-23*
+*Charter Version: 1.1.0 | Last Updated: 2026-04-13*

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -82,7 +82,7 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 
 ## Neon Auth Ownership
 
-ChittyConnect is the **canonical owner of user identity and session data** within the Neon Auth schema on ChittyOS-Core (`neon_auth` schema, Neon project `restless-grass-40598426`).
+ChittyConnect is the **canonical owner of user identity and session data** within the Neon Auth schema on ChittyOS-Core (`neon_auth` schema).
 
 ### Schema Ownership Split
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -36,9 +36,7 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 - ChittyID minting coordination
 - Legal case management via ChittyCases
 - Evidence ingestion via ChittyEvidence
-- User identity and profile management via `neon_auth.user` and `neon_auth.account` on ChittyOS-Core
-- User session management via `neon_auth.session` (when stateful sessions required)
-- Organization/membership management via `neon_auth.organization`, `neon_auth.member`
+- User identity and profile management via `neon_auth.user`, `neon_auth.account`, `neon_auth.session`, `neon_auth.organization`, `neon_auth.member`, `neon_auth.verification`, and `neon_auth.invitation` on ChittyOS-Core
 
 ### IS NOT Responsible For
 - Direct identity generation (ChittyID)
@@ -90,9 +88,7 @@ ChittyConnect is the **canonical owner of user identity and session data** withi
 
 | `neon_auth` Table | Owner | Rationale |
 |-------------------|-------|-----------|
-| `user`, `account`, `verification` | **ChittyConnect** | User profiles and credentials — per this charter's scope |
-| `session` | **ChittyConnect** | User session management |
-| `organization`, `member`, `invitation` | **ChittyConnect** | Multi-tenant org membership |
+| `user`, `account`, `session`, `organization`, `member`, `verification`, `invitation` | **ChittyConnect** | User identity, profiles, credentials, sessions, and multi-tenant org membership — per this charter's scope |
 | `jwks` | **ChittyAuth** | JWT signing keys — per ChittyAuth charter scope |
 | `project_config` | **ChittyAuth** | JWKS URL, issuer configuration |
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -100,7 +100,7 @@ ChittyConnect is the **canonical owner of user identity and session data** withi
 4. **Downstream services** validate JWTs against ChittyAuth's JWKS and use RLS policies referencing `auth.jwt() ->> 'chitty_id'` for per-user data scoping
 
 ### Migration Note (2026-04)
-The `neon_auth.user` table on ChittyOS-Core currently has 0 rows. ChittyAuth's existing user data lives in `public.users` (2 rows) and `public.identities` (73 rows). ChittyConnect will migrate user profile data to `neon_auth.user` as part of the Neon Auth unification initiative. See companion amendment: [chittyfoundation/chittyauth#4](https://github.com/chittyfoundation/chittyauth/pull/4).
+The `neon_auth.user` table on ChittyOS-Core is currently empty. ChittyAuth's existing user data remains in a small legacy dataset within `public.users` and `public.identities`. ChittyConnect will migrate user profile data to `neon_auth.user` as part of the Neon Auth unification initiative. See companion amendment: [chittyfoundation/chittyauth#4](https://github.com/chittyfoundation/chittyauth/pull/4).
 
 ## API Contract
 


### PR DESCRIPTION
## Summary

- Adds **Neon Auth Ownership** section to ChittyConnect CHARTER.md establishing ChittyConnect as the canonical owner of `neon_auth.user`, `account`, `session`, `organization`, `member`, and `invitation` tables on ChittyOS-Core
- Documents the complete **User Identity Flow**: ChittyID mints → ChittyConnect writes profiles → ChittyAuth signs JWTs → downstream services use RLS
- Adds user identity and session management to the "IS Responsible For" scope
- Includes migration note documenting current orphaned state (0 rows) and cross-references the companion ChittyAuth amendment

## Companion PR

This is the ChittyConnect half of the Neon Auth ownership split. The ChittyAuth half is at [chittyfoundation/chittyauth#4](https://github.com/chittyfoundation/chittyauth/pull/4).

Together they establish:
- **ChittyAuth** owns `neon_auth.jwks` + `project_config` (token signing)
- **ChittyConnect** owns `neon_auth.user` + `account` + `session` + `organization` + `member` (user identity)

## Test plan

- [ ] Review charter amendment for canonical accuracy
- [ ] Verify ownership split is consistent with chittyauth#4
- [ ] Confirm no conflicts with ChittyConnect's existing user management code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version updated to 1.1.0 with new date
  * Expanded scope to include user identity, session, and organization/membership management capabilities
  * Added ownership assignments and identity flow documentation
  * Added user data migration plan

<!-- end of auto-generated comment: release notes by coderabbit.ai -->