### PR TITLE
feat: channel-agnostic session sync endpoint for Desktop parity

### DIFF
--- a/src/api/router.js
+++ b/src/api/router.js
@@ -39,6 +39,7 @@ import { authKeysRoutes } from "./routes/auth-keys.js";
 import { promptRoutes } from "./routes/prompts.js";
 import { tenantRoutes } from "./routes/tenants.js";
 import { migrationRoutes } from "./routes/tenant-migration.js";
+import { sessionRoutes } from "./routes/sessions.js";
 import { authenticate } from "./middleware/auth.js";
 import { autoRateLimit } from "./middleware/rate-limit.js";
 import openapiSpec from "../../public/openapi.json";
@@ -125,6 +126,7 @@ api.get("/api/health", (c) => {
       connections: "/api/connections",
       prompts: "/api/v1/context/prompts",
       tenants: "/api/v1/tenants",
+      sessions: "/api/v1/sessions",
       mcp: "/mcp",
       chatgptMcp: "/chatgpt/mcp",
     },
@@ -185,5 +187,6 @@ api.route("/api/auth/keys", authKeysRoutes);
 api.route("/api/v1/context/prompts", promptRoutes);
 api.route("/api/v1/tenants/migration", migrationRoutes);
 api.route("/api/v1/tenants", tenantRoutes);
+api.route("/api/v1/sessions", sessionRoutes);
 
 export { api };

--- a/src/api/routes/sessions.js
+++ b/src/api/routes/sessions.js
@@ -141,7 +141,21 @@ sessionRoutes.get("/", async (c) => {
  */
 sessionRoutes.post("/sync", async (c) => {
   try {
-    const body = await c.req.json();
+    let body;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "INVALID_JSON",
+            message: "Request body must be valid JSON",
+          },
+        },
+        400,
+      );
+    }
     const {
       event,
       chittyId,
@@ -316,6 +330,7 @@ sessionRoutes.post("/sync", async (c) => {
         sessionService
           .updateSession(chittyId, sessionId, {
             status: "ended",
+            state: "ended",
             endedAt: timestamp,
           })
           .then(() => "session_ended")
@@ -324,7 +339,7 @@ sessionRoutes.post("/sync", async (c) => {
               "[Sessions/Sync] Session end update failed:",
               err.message,
             );
-            return null;
+            return "session_end_failed";
           }),
 
         // 2. Unbind session in D1 ledger
@@ -389,35 +404,18 @@ sessionRoutes.post("/sync", async (c) => {
       }
     }
 
-    // Notion update (both events, independent of everything above)
+    // Fire-and-forget Notion update via waitUntil — doesn't block response
     if (notion?.projectPageId) {
-      try {
-        const notionToken = await getCredential(
-          c.env,
-          "integrations/notion/api_key",
-          "NOTION_TOKEN",
-        );
-        if (notionToken) {
-          const notionProperties = {
-            properties: {
-              "Session Status": {
-                select: {
-                  name: event === "session_start" ? "Active" : "Ended",
-                },
-              },
-              "Last Session": {
-                rich_text: [
-                  {
-                    text: {
-                      content: `${sessionId} | ${channel?.type || "unknown"} | ${channel?.machine || "unknown"} | ${timestamp}`,
-                    },
-                  },
-                ],
-              },
-            },
-          };
+      const notionUpdate = async () => {
+        try {
+          const notionToken = await getCredential(
+            c.env,
+            "integrations/notion/api_key",
+            "NOTION_TOKEN",
+          );
+          if (!notionToken) return;
 
-          const notionResp = await fetch(
+          const resp = await fetch(
             `https://api.notion.com/v1/pages/${notion.projectPageId}`,
             {
               method: "PATCH",
@@ -426,23 +424,42 @@ sessionRoutes.post("/sync", async (c) => {
                 "Notion-Version": "2022-06-28",
                 "Content-Type": "application/json",
               },
-              body: JSON.stringify(notionProperties),
+              body: JSON.stringify({
+                properties: {
+                  "Session Status": {
+                    select: {
+                      name: event === "session_start" ? "Active" : "Ended",
+                    },
+                  },
+                  "Last Session": {
+                    rich_text: [
+                      {
+                        text: {
+                          content: `${sessionId} | ${channel?.type || "unknown"} | ${channel?.machine || "unknown"} | ${timestamp}`,
+                        },
+                      },
+                    ],
+                  },
+                },
+              }),
             },
           );
-
-          if (notionResp.ok) {
-            result.actions.push("notion_updated");
-          } else {
+          if (!resp.ok) {
             console.error(
               "[Sessions/Sync] Notion update failed:",
-              notionResp.status,
+              resp.status,
             );
-            result.actions.push("notion_update_failed");
           }
+        } catch (err) {
+          console.error("[Sessions/Sync] Notion error:", err.message);
         }
-      } catch (err) {
-        console.error("[Sessions/Sync] Notion error:", err.message);
+      };
+      if (c.executionCtx?.waitUntil) {
+        c.executionCtx.waitUntil(notionUpdate());
+      } else {
+        notionUpdate();
       }
+      result.actions.push("notion_queued");
     }
 
     return c.json({ success: true, data: result });

--- a/src/api/routes/sessions.js
+++ b/src/api/routes/sessions.js
@@ -1,502 +1,723 @@
 /**
  * Session Management Routes
  *
- * Handles session lifecycle using Durable Objects for ContextConsciousness™
+ * Handles session lifecycle using Durable Objects for ContextConsciousness™.
+ * The /sync endpoint provides channel-agnostic session lifecycle parity,
+ * replacing the VM-only bash hook pipeline with a single HTTP call.
+ *
+ * @canonical-uri chittycanon://core/services/chittyconnect/api/routes/sessions
+ * @canon chittycanon://gov/governance#core-types
  */
 
+import { Hono } from "hono";
 import { SessionStateService } from "../../services/SessionStateService.js";
+import { getCredential } from "../../lib/credential-helper.js";
 
-export function registerSessionRoutes(app) {
-  /**
-   * Create a new session
-   * POST /api/v1/sessions
-   */
-  app.post("/api/v1/sessions", async (c) => {
-    try {
-      const { chittyId, sessionId, metadata } = await c.req.json();
+const sessionRoutes = new Hono();
 
-      if (!chittyId || !sessionId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_REQUIRED_FIELDS",
-              message: "chittyId and sessionId are required",
-            },
-          },
-          400,
-        );
-      }
-
-      // Initialize session service
-      const sessionService = new SessionStateService(c.env);
-
-      // Create session in Durable Object
-      const session = await sessionService.createSession(
-        chittyId,
-        sessionId,
-        metadata || {},
-      );
-
-      // Log creation in ContextConsciousness™
-      if (c.env.CONTEXT_CONSCIOUSNESS) {
-        await c.env.CONTEXT_CONSCIOUSNESS.addDecision(chittyId, {
-          type: "session_created",
-          sessionId,
-          reasoning: "New session initiated for ContextConsciousness™",
-          confidence: 1.0,
-          context: { metadata },
-        });
-      }
-
-      return c.json({
-        success: true,
-        data: session,
-        metadata: {
-          timestamp: new Date().toISOString(),
-          requestId: crypto.randomUUID(),
-        },
-      });
-    } catch (error) {
-      console.error("[Sessions] Create error:", error);
+// Require X-ChittyID header on all parameterized session routes.
+// Excludes fixed paths (/, /sync) which handle auth differently.
+function requireChittyId() {
+  return async (c, next) => {
+    const chittyId = c.req.header("X-ChittyID");
+    if (!chittyId) {
       return c.json(
         {
           success: false,
           error: {
-            code: "SESSION_CREATE_FAILED",
-            message: error.message,
+            code: "MISSING_CHITTYID",
+            message: "X-ChittyID header is required",
           },
         },
-        500,
+        400,
       );
     }
-  });
-
-  /**
-   * Get session details
-   * GET /api/v1/sessions/:sessionId
-   */
-  app.get("/api/v1/sessions/:sessionId", async (c) => {
-    try {
-      const sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const session = await sessionService.getSession(chittyId, sessionId);
-
-      if (!session) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "SESSION_NOT_FOUND",
-              message: "Session not found",
-            },
-          },
-          404,
-        );
-      }
-
-      return c.json({
-        success: true,
-        data: session,
-      });
-    } catch (error) {
-      console.error("[Sessions] Get error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "SESSION_GET_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Update session state
-   * PATCH /api/v1/sessions/:sessionId
-   */
-  app.patch("/api/v1/sessions/:sessionId", async (c) => {
-    try {
-      const sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-      const updates = await c.req.json();
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const session = await sessionService.updateSession(
-        chittyId,
-        sessionId,
-        updates,
-      );
-
-      return c.json({
-        success: true,
-        data: session,
-      });
-    } catch (error) {
-      console.error("[Sessions] Update error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "SESSION_UPDATE_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * List all sessions for a ChittyID
-   * GET /api/v1/sessions
-   */
-  app.get("/api/v1/sessions", async (c) => {
-    try {
-      const chittyId = c.req.header("X-ChittyID");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const result = await sessionService.listSessions(chittyId);
-
-      return c.json({
-        success: true,
-        data: result,
-      });
-    } catch (error) {
-      console.error("[Sessions] List error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "SESSION_LIST_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Get session context
-   * GET /api/v1/sessions/:sessionId/context
-   */
-  app.get("/api/v1/sessions/:sessionId/context", async (c) => {
-    try {
-      const _sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-      const key = c.req.query("key");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const context = await sessionService.getContext(chittyId, key);
-
-      return c.json({
-        success: true,
-        data: context,
-      });
-    } catch (error) {
-      console.error("[Sessions] Get context error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "CONTEXT_GET_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Set session context
-   * PUT /api/v1/sessions/:sessionId/context
-   */
-  app.put("/api/v1/sessions/:sessionId/context", async (c) => {
-    try {
-      const _sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-      const { key, value } = await c.req.json();
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      if (!key) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_KEY",
-              message: "Context key is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const result = await sessionService.setContext(chittyId, key, value);
-
-      return c.json({
-        success: true,
-        data: result,
-      });
-    } catch (error) {
-      console.error("[Sessions] Set context error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "CONTEXT_SET_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Get session metrics
-   * GET /api/v1/sessions/:sessionId/metrics
-   */
-  app.get("/api/v1/sessions/:sessionId/metrics", async (c) => {
-    try {
-      const _sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const metrics = await sessionService.getMetrics(chittyId);
-
-      return c.json({
-        success: true,
-        data: metrics,
-      });
-    } catch (error) {
-      console.error("[Sessions] Get metrics error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "METRICS_GET_FAILED",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Establish WebSocket connection for real-time updates
-   * GET /api/v1/sessions/:sessionId/ws
-   */
-  app.get("/api/v1/sessions/:sessionId/ws", async (c) => {
-    try {
-      const sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      // Check for WebSocket upgrade header
-      if (c.req.header("Upgrade") !== "websocket") {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "WEBSOCKET_REQUIRED",
-              message: "WebSocket upgrade required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const webSocket = await sessionService.connectWebSocket(
-        chittyId,
-        sessionId,
-      );
-
-      if (!webSocket) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "WEBSOCKET_FAILED",
-              message: "Failed to establish WebSocket connection",
-            },
-          },
-          500,
-        );
-      }
-
-      return new Response(null, {
-        status: 101,
-        webSocket,
-      });
-    } catch (error) {
-      console.error("[Sessions] WebSocket error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "WEBSOCKET_ERROR",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
-
-  /**
-   * Migrate existing KV session to Durable Object
-   * POST /api/v1/sessions/:sessionId/migrate
-   */
-  app.post("/api/v1/sessions/:sessionId/migrate", async (c) => {
-    try {
-      const sessionId = c.req.param("sessionId");
-      const chittyId = c.req.header("X-ChittyID");
-
-      if (!chittyId) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MISSING_CHITTYID",
-              message: "X-ChittyID header is required",
-            },
-          },
-          400,
-        );
-      }
-
-      const sessionService = new SessionStateService(c.env);
-      const session = await sessionService.migrateSession(chittyId, sessionId);
-
-      if (!session) {
-        return c.json(
-          {
-            success: false,
-            error: {
-              code: "MIGRATION_FAILED",
-              message: "No session found to migrate or migration failed",
-            },
-          },
-          404,
-        );
-      }
-
-      return c.json({
-        success: true,
-        data: session,
-        message: "Session successfully migrated to Durable Objects",
-      });
-    } catch (error) {
-      console.error("[Sessions] Migration error:", error);
-      return c.json(
-        {
-          success: false,
-          error: {
-            code: "MIGRATION_ERROR",
-            message: error.message,
-          },
-        },
-        500,
-      );
-    }
-  });
+    c.set("chittyId", chittyId);
+    await next();
+  };
 }
+
+sessionRoutes.post("/", async (c) => {
+  try {
+    const { chittyId, sessionId, metadata } = await c.req.json();
+
+    if (!chittyId || !sessionId) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "MISSING_REQUIRED_FIELDS",
+            message: "chittyId and sessionId are required",
+          },
+        },
+        400,
+      );
+    }
+
+    const sessionService = new SessionStateService(c.env);
+    const session = await sessionService.createSession(
+      chittyId,
+      sessionId,
+      metadata || {},
+    );
+
+    if (c.env.CONTEXT_CONSCIOUSNESS) {
+      await c.env.CONTEXT_CONSCIOUSNESS.addDecision(chittyId, {
+        type: "session_created",
+        sessionId,
+        reasoning: "New session initiated for ContextConsciousness™",
+        confidence: 1.0,
+        context: { metadata },
+      });
+    }
+
+    return c.json({
+      success: true,
+      data: session,
+      metadata: {
+        timestamp: new Date().toISOString(),
+        requestId: crypto.randomUUID(),
+      },
+    });
+  } catch (error) {
+    console.error("[Sessions] Create error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "SESSION_CREATE_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.get("/", async (c) => {
+  try {
+    const chittyId = c.req.header("X-ChittyID");
+
+    if (!chittyId) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "MISSING_CHITTYID",
+            message: "X-ChittyID header is required",
+          },
+        },
+        400,
+      );
+    }
+
+    const sessionService = new SessionStateService(c.env);
+    const result = await sessionService.listSessions(chittyId);
+
+    return c.json({
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    console.error("[Sessions] List error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "SESSION_LIST_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Channel-agnostic session lifecycle sync.
+ * Replaces the VM-only bash hook pipeline with a single HTTP call.
+ *
+ * POST /sync
+ */
+sessionRoutes.post("/sync", async (c) => {
+  try {
+    const body = await c.req.json();
+    const {
+      event,
+      chittyId,
+      sessionId,
+      channel,
+      project,
+      coordinates,
+      context,
+      signals,
+      notion,
+    } = body;
+
+    if (!event || !chittyId || !sessionId) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "MISSING_REQUIRED_FIELDS",
+            message: "event, chittyId, and sessionId are required",
+          },
+        },
+        400,
+      );
+    }
+
+    if (event !== "session_start" && event !== "session_end") {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "INVALID_EVENT",
+            message: "event must be session_start or session_end",
+          },
+        },
+        400,
+      );
+    }
+
+    const timestamp = new Date().toISOString();
+    const result = { event, sessionId, chittyId, timestamp, actions: [] };
+
+    // Context key includes org when available for namespace isolation
+    const projectContextKey = project?.slug
+      ? `project:${project.org ? `${project.org}:` : ""}${project.slug}`
+      : null;
+
+    const sessionService = new SessionStateService(c.env);
+    const contextResolver = c.get("contextResolver");
+
+    if (event === "session_start") {
+      const metadata = {
+        channel: channel || { type: "unknown" },
+        project: project || {},
+        coordinates: coordinates || {},
+        startedAt: timestamp,
+      };
+
+      // All three operations are independent — run in parallel
+      const [sessionResult, ledgerResult, contextResult] =
+        await Promise.allSettled([
+          // 1. Create session in Durable Object
+          sessionService.createSession(chittyId, sessionId, metadata),
+
+          // 2. Bind session in D1 ledger
+          contextResolver
+            ? contextResolver
+                .loadContextByChittyId(chittyId)
+                .then((entity) =>
+                  entity
+                    ? contextResolver.bindSession(
+                        entity.id,
+                        chittyId,
+                        sessionId,
+                        channel?.type || "unknown",
+                      )
+                    : null,
+                )
+            : Promise.resolve(null),
+
+          // 3. Load prior project context for hydration
+          projectContextKey
+            ? sessionService.getContext(chittyId, projectContextKey)
+            : Promise.resolve(null),
+        ]);
+
+      if (sessionResult.status === "fulfilled") {
+        result.session = sessionResult.value;
+        result.actions.push("session_created");
+      } else {
+        console.error(
+          "[Sessions/Sync] Session create failed:",
+          sessionResult.reason?.message,
+        );
+        result.actions.push("session_create_failed");
+      }
+
+      if (ledgerResult.status === "fulfilled" && ledgerResult.value) {
+        result.actions.push("ledger_session_bound");
+      } else if (ledgerResult.status === "rejected") {
+        console.error(
+          "[Sessions/Sync] Ledger bind failed:",
+          ledgerResult.reason?.message,
+        );
+        result.actions.push("ledger_bind_failed");
+      }
+
+      if (contextResult.status === "fulfilled" && contextResult.value) {
+        result.priorContext = contextResult.value;
+        result.actions.push("prior_context_loaded");
+      }
+    }
+
+    if (event === "session_end") {
+      // Build memory interaction object (needed by persist, independent of writes)
+      const memory = c.get("memory");
+      let interaction = null;
+      if (memory && context) {
+        const parts = [];
+        if (project?.slug) parts.push(`Project: ${project.slug}`);
+        if (context.summary)
+          parts.push(`Session summary: ${context.summary}`);
+        if (context.keyFacts?.length)
+          parts.push(
+            `Key facts: ${context.keyFacts.slice(0, 8).join("; ")}`,
+          );
+        if (context.pendingTasks?.length)
+          parts.push(
+            `Pending tasks: ${context.pendingTasks.slice(0, 8).join("; ")}`,
+          );
+        if (context.completedTasks?.length)
+          parts.push(
+            `Completed tasks: ${context.completedTasks.slice(0, 8).join("; ")}`,
+          );
+
+        const memoryContent = parts.join("\n").slice(0, 6000);
+        const tags = [
+          "session_sync",
+          "session_end",
+          "memorycloude_sync",
+          channel?.type || "unknown_channel",
+        ];
+        if (project?.slug) tags.push(`project:${project.slug}`);
+
+        interaction = {
+          type: "session_sync_end",
+          content: memoryContent,
+          input: context.summary || "",
+          // "chittyId" type matches MemoryCloude contract + bash drain shape.
+          // Owner is Person (P). @canon: chittycanon://gov/governance#core-types
+          entities: [{ type: "chittyId", id: chittyId }],
+          actions: tags.map((t) => ({ type: `tag:${t}` })),
+          decisions: (context.completedTasks || [])
+            .slice(0, 8)
+            .map((val, idx) => ({
+              id: `done-${idx + 1}`,
+              text: String(val),
+            })),
+          userId: chittyId,
+          metadata: {
+            projectSlug: project?.slug,
+            summary: context.summary,
+            channel: channel || {},
+            taskSignals: signals?.tasks || {},
+            gitSignals: signals?.git || {},
+          },
+        };
+      }
+
+      // All end operations are independent writes — run in parallel
+      const endOps = [
+        // 1. Update session status
+        sessionService
+          .updateSession(chittyId, sessionId, {
+            status: "ended",
+            endedAt: timestamp,
+          })
+          .then(() => "session_ended")
+          .catch((err) => {
+            console.error(
+              "[Sessions/Sync] Session end update failed:",
+              err.message,
+            );
+            return null;
+          }),
+
+        // 2. Unbind session in D1 ledger
+        contextResolver
+          ? contextResolver
+              .unbindSession(sessionId, {
+                interactions: signals?.tasks?.completed || 0,
+                decisions: context?.completedTasks?.length || 0,
+                successRate: null,
+              })
+              .then(() => "ledger_session_unbound")
+              .catch((err) => {
+                console.error(
+                  "[Sessions/Sync] Ledger unbind failed:",
+                  err.message,
+                );
+                return "ledger_unbind_failed";
+              })
+          : Promise.resolve(null),
+
+        // 3. Persist to MemoryCloude™
+        interaction
+          ? memory
+              .persistInteraction(sessionId, interaction)
+              .then(() => "memory_persisted")
+              .catch((err) => {
+                console.error(
+                  "[Sessions/Sync] Memory persist failed:",
+                  err.message,
+                );
+                return "memory_persist_failed";
+              })
+          : Promise.resolve(null),
+
+        // 4. Save project context for next session hydration
+        projectContextKey && context
+          ? sessionService
+              .setContext(chittyId, projectContextKey, {
+                summary: context.summary,
+                keyFacts: context.keyFacts?.slice(0, 8),
+                pendingTasks: context.pendingTasks?.slice(0, 8),
+                completedTasks: context.completedTasks?.slice(0, 8),
+                coordinates: coordinates || {},
+                lastChannel: channel || {},
+                lastSessionId: sessionId,
+                updatedAt: timestamp,
+              })
+              .then(() => "project_context_saved")
+              .catch((err) => {
+                console.error(
+                  "[Sessions/Sync] Context save failed:",
+                  err.message,
+                );
+                return null;
+              })
+          : Promise.resolve(null),
+      ];
+
+      const endResults = await Promise.all(endOps);
+      for (const action of endResults) {
+        if (action) result.actions.push(action);
+      }
+    }
+
+    // Notion update (both events, independent of everything above)
+    if (notion?.projectPageId) {
+      try {
+        const notionToken = await getCredential(
+          c.env,
+          "integrations/notion/api_key",
+          "NOTION_TOKEN",
+        );
+        if (notionToken) {
+          const notionProperties = {
+            properties: {
+              "Session Status": {
+                select: {
+                  name: event === "session_start" ? "Active" : "Ended",
+                },
+              },
+              "Last Session": {
+                rich_text: [
+                  {
+                    text: {
+                      content: `${sessionId} | ${channel?.type || "unknown"} | ${channel?.machine || "unknown"} | ${timestamp}`,
+                    },
+                  },
+                ],
+              },
+            },
+          };
+
+          const notionResp = await fetch(
+            `https://api.notion.com/v1/pages/${notion.projectPageId}`,
+            {
+              method: "PATCH",
+              headers: {
+                Authorization: `Bearer ${notionToken}`,
+                "Notion-Version": "2022-06-28",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(notionProperties),
+            },
+          );
+
+          if (notionResp.ok) {
+            result.actions.push("notion_updated");
+          } else {
+            console.error(
+              "[Sessions/Sync] Notion update failed:",
+              notionResp.status,
+            );
+            result.actions.push("notion_update_failed");
+          }
+        }
+      } catch (err) {
+        console.error("[Sessions/Sync] Notion error:", err.message);
+      }
+    }
+
+    return c.json({ success: true, data: result });
+  } catch (error) {
+    console.error("[Sessions/Sync] Error:", error);
+    return c.json(
+      {
+        success: false,
+        error: { code: "SESSION_SYNC_FAILED", message: error.message },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.get("/:sessionId", requireChittyId(), async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const chittyId = c.get("chittyId");
+
+    const sessionService = new SessionStateService(c.env);
+    const session = await sessionService.getSession(chittyId, sessionId);
+
+    if (!session) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "SESSION_NOT_FOUND",
+            message: "Session not found",
+          },
+        },
+        404,
+      );
+    }
+
+    return c.json({
+      success: true,
+      data: session,
+    });
+  } catch (error) {
+    console.error("[Sessions] Get error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "SESSION_GET_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.patch("/:sessionId", requireChittyId(), async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const chittyId = c.get("chittyId");
+    const updates = await c.req.json();
+
+    const sessionService = new SessionStateService(c.env);
+    const session = await sessionService.updateSession(
+      chittyId,
+      sessionId,
+      updates,
+    );
+
+    return c.json({
+      success: true,
+      data: session,
+    });
+  } catch (error) {
+    console.error("[Sessions] Update error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "SESSION_UPDATE_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.get("/:sessionId/context", requireChittyId(), async (c) => {
+  try {
+    const chittyId = c.get("chittyId");
+    const key = c.req.query("key");
+
+    const sessionService = new SessionStateService(c.env);
+    const context = await sessionService.getContext(chittyId, key);
+
+    return c.json({
+      success: true,
+      data: context,
+    });
+  } catch (error) {
+    console.error("[Sessions] Get context error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "CONTEXT_GET_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.put("/:sessionId/context", requireChittyId(), async (c) => {
+  try {
+    const chittyId = c.get("chittyId");
+    const { key, value } = await c.req.json();
+
+    if (!key) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "MISSING_KEY",
+            message: "Context key is required",
+          },
+        },
+        400,
+      );
+    }
+
+    const sessionService = new SessionStateService(c.env);
+    const result = await sessionService.setContext(chittyId, key, value);
+
+    return c.json({
+      success: true,
+      data: result,
+    });
+  } catch (error) {
+    console.error("[Sessions] Set context error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "CONTEXT_SET_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.get("/:sessionId/metrics", requireChittyId(), async (c) => {
+  try {
+    const chittyId = c.get("chittyId");
+
+    const sessionService = new SessionStateService(c.env);
+    const metrics = await sessionService.getMetrics(chittyId);
+
+    return c.json({
+      success: true,
+      data: metrics,
+    });
+  } catch (error) {
+    console.error("[Sessions] Get metrics error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "METRICS_GET_FAILED",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.get("/:sessionId/ws", requireChittyId(), async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const chittyId = c.get("chittyId");
+
+    if (c.req.header("Upgrade") !== "websocket") {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "WEBSOCKET_REQUIRED",
+            message: "WebSocket upgrade required",
+          },
+        },
+        400,
+      );
+    }
+
+    const sessionService = new SessionStateService(c.env);
+    const webSocket = await sessionService.connectWebSocket(
+      chittyId,
+      sessionId,
+    );
+
+    if (!webSocket) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "WEBSOCKET_FAILED",
+            message: "Failed to establish WebSocket connection",
+          },
+        },
+        500,
+      );
+    }
+
+    return new Response(null, {
+      status: 101,
+      webSocket,
+    });
+  } catch (error) {
+    console.error("[Sessions] WebSocket error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "WEBSOCKET_ERROR",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+sessionRoutes.post("/:sessionId/migrate", requireChittyId(), async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const chittyId = c.get("chittyId");
+
+    const sessionService = new SessionStateService(c.env);
+    const session = await sessionService.migrateSession(chittyId, sessionId);
+
+    if (!session) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "MIGRATION_FAILED",
+            message: "No session found to migrate or migration failed",
+          },
+        },
+        404,
+      );
+    }
+
+    return c.json({
+      success: true,
+      data: session,
+      message: "Session successfully migrated to Durable Objects",
+    });
+  } catch (error) {
+    console.error("[Sessions] Migration error:", error);
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "MIGRATION_ERROR",
+          message: error.message,
+        },
+      },
+      500,
+    );
+  }
+});
+
+export { sessionRoutes };

--- a/src/lib/trust-resolver.js
+++ b/src/lib/trust-resolver.js
@@ -24,9 +24,9 @@ const CACHE_TTL = 300; // 5 minutes
  * Derive trust_level (0-5) from TY/VY/RY reckoning.
  * Uses floor of the average, scaled to 0-5.
  *
- * @param {number} ty - Identity Substrate (0-1)
- * @param {number} vy - Verified Yesterday (0-1)
- * @param {number} ry - Reach and Authority (0-1)
+ * @param {number} ty - idenTitY (0-1)
+ * @param {number} vy - connectiVitY (0-1)
+ * @param {number} ry - authoRitY (0-1)
  * @returns {number} trust_level 0-5
  */
 function deriveTrustLevel(ty, vy, ry) {

--- a/tests/api/session-sync-routes.test.js
+++ b/tests/api/session-sync-routes.test.js
@@ -1,0 +1,234 @@
+/**
+ * Tests for POST /api/v1/sessions/sync
+ *
+ * Channel-agnostic session lifecycle endpoint.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { sessionRoutes } from "../../src/api/routes/sessions.js";
+
+const mockMemory = {
+  persistInteraction: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockContextResolver = {
+  loadContextByChittyId: vi.fn().mockResolvedValue({
+    id: "ctx-001",
+    chitty_id: "03-1-USA-5537-P-2602-0-38",
+    status: "active",
+  }),
+  bindSession: vi.fn().mockResolvedValue({ bindingId: "bind-001" }),
+  unbindSession: vi.fn().mockResolvedValue(null),
+};
+
+const mockSessionService = {
+  createSession: vi.fn().mockResolvedValue({ sessionId: "s1", status: "active" }),
+  updateSession: vi.fn().mockResolvedValue({ sessionId: "s1", status: "ended" }),
+  getContext: vi.fn().mockResolvedValue(null),
+  setContext: vi.fn().mockResolvedValue({ ok: true }),
+  listSessions: vi.fn().mockResolvedValue([]),
+  getSession: vi.fn().mockResolvedValue(null),
+  getMetrics: vi.fn().mockResolvedValue({}),
+};
+
+// Mock SessionStateService constructor — must use function (not arrow) for new
+vi.mock("../../src/services/SessionStateService.js", () => ({
+  SessionStateService: vi.fn().mockImplementation(function () {
+    Object.assign(this, mockSessionService);
+  }),
+}));
+
+// Mock credential helper
+vi.mock("../../src/lib/credential-helper.js", () => ({
+  getCredential: vi.fn().mockResolvedValue(null),
+}));
+
+function createTestApp() {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("memory", mockMemory);
+    c.set("contextResolver", mockContextResolver);
+    c.env = c.env || {};
+    await next();
+  });
+  app.route("/api/v1/sessions", sessionRoutes);
+  return app;
+}
+
+describe("POST /api/v1/sessions/sync", () => {
+  let app;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = createTestApp();
+  });
+
+  it("rejects missing required fields", async () => {
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event: "session_start" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("MISSING_REQUIRED_FIELDS");
+  });
+
+  it("rejects invalid event type", async () => {
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_pause",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "s1",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_EVENT");
+  });
+
+  it("handles session_start and creates session", async () => {
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_start",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "session-1234",
+        channel: { type: "claude_desktop", machine: "macbook-pro" },
+        project: { slug: "chittyconnect", org: "CHITTYOS" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.event).toBe("session_start");
+    expect(body.data.actions).toContain("session_created");
+    expect(body.data.actions).toContain("ledger_session_bound");
+    expect(mockSessionService.createSession).toHaveBeenCalledWith(
+      "03-1-USA-5537-P-2602-0-38",
+      "session-1234",
+      expect.objectContaining({
+        channel: { type: "claude_desktop", machine: "macbook-pro" },
+        project: { slug: "chittyconnect", org: "CHITTYOS" },
+      }),
+    );
+    expect(mockContextResolver.bindSession).toHaveBeenCalledWith(
+      "ctx-001",
+      "03-1-USA-5537-P-2602-0-38",
+      "session-1234",
+      "claude_desktop",
+    );
+  });
+
+  it("loads prior context on session_start when available", async () => {
+    const priorCtx = {
+      summary: "Working on session sync endpoint",
+      keyFacts: ["converted to Hono sub-router"],
+    };
+    mockSessionService.getContext.mockResolvedValueOnce(priorCtx);
+
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_start",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "session-5678",
+        project: { slug: "chittyconnect" },
+      }),
+    });
+    const body = await res.json();
+    expect(body.data.priorContext).toEqual(priorCtx);
+    expect(body.data.actions).toContain("prior_context_loaded");
+  });
+
+  it("handles session_end with memory persist and context save", async () => {
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_end",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "session-1234",
+        channel: { type: "claude_desktop", machine: "macbook-pro" },
+        project: { slug: "chittyconnect", org: "CHITTYOS" },
+        context: {
+          summary: "Built session sync endpoint",
+          keyFacts: ["converted sessions.js to Hono sub-router"],
+          completedTasks: ["sync endpoint", "router wiring"],
+          pendingTasks: ["write tests"],
+        },
+        signals: {
+          git: { branch: "feat/session-sync", staged: 2, modified: 0 },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.actions).toContain("session_ended");
+    expect(body.data.actions).toContain("ledger_session_unbound");
+    expect(body.data.actions).toContain("memory_persisted");
+    expect(body.data.actions).toContain("project_context_saved");
+
+    // Verify memory was persisted with correct shape
+    expect(mockMemory.persistInteraction).toHaveBeenCalledWith(
+      "session-1234",
+      expect.objectContaining({
+        type: "session_sync_end",
+        userId: "03-1-USA-5537-P-2602-0-38",
+        content: expect.stringContaining("Built session sync endpoint"),
+      }),
+    );
+
+    // Verify project context was saved for next session
+    expect(mockSessionService.setContext).toHaveBeenCalledWith(
+      "03-1-USA-5537-P-2602-0-38",
+      "project:CHITTYOS:chittyconnect",
+      expect.objectContaining({
+        summary: "Built session sync endpoint",
+        lastSessionId: "session-1234",
+      }),
+    );
+  });
+
+  it("session_end without context does not persist memory", async () => {
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_end",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "session-empty",
+      }),
+    });
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.actions).toContain("session_ended");
+    expect(body.data.actions).not.toContain("memory_persisted");
+    expect(mockMemory.persistInteraction).not.toHaveBeenCalled();
+  });
+
+  it("gracefully handles SessionStateService failures", async () => {
+    mockSessionService.createSession.mockRejectedValueOnce(
+      new Error("DO unavailable"),
+    );
+
+    const res = await app.request("/api/v1/sessions/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        event: "session_start",
+        chittyId: "03-1-USA-5537-P-2602-0-38",
+        sessionId: "session-fail",
+      }),
+    });
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.actions).toContain("session_create_failed");
+  });
+});


### PR DESCRIPTION
## Summary

- **New `POST /api/v1/sessions/sync`** — single HTTP endpoint replacing the VM-only 4-hook bash pipeline with a channel-agnostic call. Claude Desktop, Mobile, or any future channel can now achieve session lifecycle parity with the VM's Claude Code hooks.
- **Converted `sessions.js`** from dead `registerSessionRoutes(app)` pattern to Hono sub-router, wired into `router.js` at `/api/v1/sessions`.
- **Parallelized all async operations** — `session_start` runs 3 ops via `Promise.allSettled()`, `session_end` runs 4 ops via `Promise.all()`, ~60-75% latency reduction.
- **Extracted `requireChittyId()` middleware** — deduplicated 7 identical header-check blocks across parameterized routes.

### Storage layers touched per event

| Layer | session_start | session_end |
|---|---|---|
| Durable Objects (SessionStateService) | createSession | updateSession (ended) |
| D1 (context_session_bindings + context_ledger) | bindSession + ledger entry | unbindSession + ledger entry |
| KV (MemoryCloude) | — | persistInteraction |
| DO (project context) | getContext (hydrate) | setContext (save for next) |
| Notion API | status: Active | status: Ended |

### Audited by
- **ChittySchema Overlord** — no schema drift, no Neon interaction, approved
- **ChittyCanon Code Cardinal** — @canon annotations added, entity type documented, health endpoint updated
- **ChittyStorage Sasquatch** — correct storage primitives (DO+KV for sessions, not R2), namespace isolation improved with `project:{org}:{slug}` keys

## Test plan

- [x] 7 new tests covering validation, session_start, session_end, prior context hydration, memory persist, graceful failure handling
- [x] 343/348 tests pass (5 pre-existing failures in tool-dispatcher.test.js unchanged)
- [ ] Post-deploy: `curl -X POST https://connect.chitty.cc/api/v1/sessions/sync` with session_start/session_end payloads
- [ ] Wire Claude Desktop Mac-side daemon to call this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full sessions surface (create, list, get, update, context, metrics, migrate, websocket check) under /api/v1/sessions
  * Added /api/v1/sessions/sync to handle channel-agnostic session_start and session_end flows, returning partial outcomes/actions and supporting Notion updates

* **Tests**
  * Added comprehensive tests for the sync endpoint covering validation, start/end flows, prior-context loading, persistence, and failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->