### PR TITLE
fix: wrangler.jsonc syntax errors blocking deploy

### DIFF
--- a/src/api/routes/credentials.js
+++ b/src/api/routes/credentials.js
@@ -718,6 +718,7 @@ credentialsRoutes.put("/:vault/:item/:field", async (c) => {
     return c.json({ success: false, error: { code: "STORE_FAILED", message: error.message } }, 500);
   }
 });
+/**
  * GET /api/credentials/health
  *
  * Check credential provisioning service health

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -148,9 +148,8 @@
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
-        { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
+        // { "binding": "SVC_DISPUTES", "service": "chittydisputes" },  // TODO: uncomment when chittydisputes worker is deployed
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
-      ],
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     },
@@ -239,9 +238,8 @@
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
-        { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
+        // { "binding": "SVC_DISPUTES", "service": "chittydisputes" },  // TODO: uncomment when chittydisputes worker is deployed
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
-      ],
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     },
@@ -334,9 +332,8 @@
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
-        { "binding": "SVC_DISPUTES", "service": "chittydisputes", "environment": "production" },
+        // { "binding": "SVC_DISPUTES", "service": "chittydisputes" },  // TODO: uncomment when chittydisputes worker is deployed
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
-      ],
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     }


### PR DESCRIPTION
## Summary

- Fix SVC_STORAGE service binding placement — was after array close bracket in all 3 environments (broken by 8186f6d)
- Add missing `/**` on credentials.js health route JSDoc (caused ESLint parse error + wrangler build failure)
- Comment out SVC_DISPUTES binding until `chittydisputes` worker is deployed

Already deployed to production via local wrangler after these fixes.

## Test plan

- [x] `npx wrangler deploy --env production` succeeds
- [x] `curl https://connect.chitty.cc/health` returns ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)