### PR TITLE
fix: align tests and tool defs with SVC_STORAGE delegation

### DIFF
--- a/src/api/routes/credentials.js
+++ b/src/api/routes/credentials.js
@@ -671,12 +671,10 @@ credentialsRoutes.get("/:vault/:item/:field", async (c) => {
 });
 
 /**
-
-/**
  * PUT /api/credentials/:vault/:item/:field
  *
  * Store or update a credential in 1Password via ChittyConnect.
- * Source of truth: value → 1Password → cached in KV.
+ * Source of truth: value -> 1Password -> cached in KV.
  *
  * Body: { "value": "secret", "notes": "optional context" }
  */
@@ -707,8 +705,8 @@ credentialsRoutes.put("/:vault/:item/:field", async (c) => {
 
     try {
       await c.env.DB.prepare(
-        `INSERT INTO credential_provisions (type, service, purpose, requesting_service, created_at) VALUES (1password_store, ?, ?, ?, datetime(now))`
-      ).bind(item, field, requestingService).run();
+        `INSERT INTO credential_provisions (type, service, purpose, requesting_service, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`
+      ).bind("1password_store", item, field, requestingService).run();
     } catch (dbErr) {
       console.warn("[Credentials] Audit log failed:", dbErr.message);
     }
@@ -719,6 +717,7 @@ credentialsRoutes.put("/:vault/:item/:field", async (c) => {
     return c.json({ success: false, error: { code: "STORE_FAILED", message: error.message } }, 500);
   }
 });
+
 /**
  * GET /api/credentials/health
  *

--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -236,14 +236,23 @@ const MCP_TOOLS = [
   {
     name: "chitty_evidence_search",
     description:
-      "AI-powered semantic search over legal evidence documents. Searches the evidence R2 bucket using vector embeddings and returns ranked document chunks with relevance scores. Use for questions about case documents, financial records, correspondence, court filings.",
+      "Search indexed evidence documents through ChittyStorage. Returns matching document records with entity/doc-type tags, content hashes, and processing tier metadata.",
     inputSchema: {
       type: "object",
       properties: {
         query: {
           type: "string",
           description:
-            "Natural language search query (e.g. 'purchase price of 541 W Addison', 'closing disclosure SoFi', 'court order October 2024')",
+            "Filename or text query to match against indexed documents",
+        },
+        entity_slug: {
+          type: "string",
+          description: "Optional entity slug filter",
+        },
+        max_num_results: {
+          type: "number",
+          description: "Maximum number of document records to return (default: 10)",
+          default: 10,
         },
       },
       required: ["query"],
@@ -252,7 +261,7 @@ const MCP_TOOLS = [
   {
     name: "chitty_evidence_retrieve",
     description:
-      "Retrieve matching evidence documents by semantic similarity (no AI generation). Returns ranked document chunks with scores. Use when you need raw document matches without an AI-generated summary.",
+      "Retrieve a specific evidence document record from ChittyStorage by content hash, evidence ID, or query fallback. Returns document metadata plus a direct file URL.",
     inputSchema: {
       type: "object",
       properties: {
@@ -260,13 +269,20 @@ const MCP_TOOLS = [
           type: "string",
           description: "Natural language search query",
         },
-        max_num_results: {
-          type: "number",
-          description: "Maximum number of results (default: 10)",
-          default: 10,
+        content_hash: {
+          type: "string",
+          description: "Exact SHA-256 content hash for the document",
+        },
+        evidence_id: {
+          type: "string",
+          description: "Evidence/document identifier to resolve",
         },
       },
-      required: ["query"],
+      anyOf: [
+        { required: ["query"] },
+        { required: ["content_hash"] },
+        { required: ["evidence_id"] },
+      ],
     },
   },
 


### PR DESCRIPTION
## Summary
- Updates evidence search/retrieve tests to use `SVC_STORAGE` service binding mock instead of old `AI_SEARCH_TOKEN` / Vectorize API patterns
- Updates tool registry descriptions for `chitty_evidence_search` and `chitty_evidence_retrieve` to reflect ChittyStorage delegation
- Fixes SQL syntax error in `credentials.js` PUT route (unquoted string literal in INSERT)
- Removes duplicate doc comment opener in `credentials.js`

Fixes 5 test failures introduced by 8186f6d but not caught because the test file wasn't updated in that commit.

## Test plan
- [x] `npx vitest run tests/mcp/tool-dispatcher.test.js` — 82/82 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)