### PR TITLE
feat: Gmail proxy routes for evidence backfill

### DIFF
--- a/src/api/routes/thirdparty.js
+++ b/src/api/routes/thirdparty.js
@@ -1013,39 +1013,44 @@ thirdpartyRoutes.post("/mercury/refresh", async (c, next) => {
 // that powers Google Calendar. Requires gmail.readonly scope on the
 // OAuth app (same refresh token rotated by SecretRotationService).
 
+const GMAIL_ALLOWED_FORMATS = new Set(["minimal", "full", "raw", "metadata"]);
+
+async function gmailFetch(googleToken, path) {
+  const response = await fetch(
+    `https://gmail.googleapis.com/gmail/v1${path}`,
+    { headers: { Authorization: `Bearer ${googleToken}` } },
+  );
+  if (!response.ok) {
+    return { ok: false, status: response.status, errorBody: await response.text() };
+  }
+  return { ok: true, response };
+}
+
 /**
  * GET /api/thirdparty/gmail/messages
  * List Gmail messages (metadata only)
  */
 thirdpartyRoutes.get("/gmail/messages", async (c) => {
   try {
-    const { q, maxResults = "10", pageToken } = c.req.query();
-
     const googleToken = await getCredential(
       c.env,
       "integrations/google/access_token",
       "GOOGLE_ACCESS_TOKEN",
     );
-
     if (!googleToken) {
       return c.json({ error: "Google access token not configured" }, 503);
     }
 
+    const { q, maxResults = "10", pageToken } = c.req.query();
     const params = new URLSearchParams({ maxResults });
     if (q) params.append("q", q);
     if (pageToken) params.append("pageToken", pageToken);
 
-    const response = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/messages?${params.toString()}`,
-      { headers: { Authorization: `Bearer ${googleToken}` } },
-    );
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    const result = await gmailFetch(googleToken, `/users/me/messages?${params.toString()}`);
+    if (!result.ok) {
+      return c.json({ error: `Gmail API error: ${result.status}` }, result.status);
     }
-
-    return c.json(await response.json());
+    return c.json(await result.response.json());
   } catch (error) {
     return c.json({ error: error.message }, 500);
   }
@@ -1057,30 +1062,27 @@ thirdpartyRoutes.get("/gmail/messages", async (c) => {
  */
 thirdpartyRoutes.get("/gmail/message/:messageId", async (c) => {
   try {
-    const { messageId } = c.req.param();
-    const { format = "metadata" } = c.req.query();
-
     const googleToken = await getCredential(
       c.env,
       "integrations/google/access_token",
       "GOOGLE_ACCESS_TOKEN",
     );
-
     if (!googleToken) {
       return c.json({ error: "Google access token not configured" }, 503);
     }
 
-    const response = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=${format}`,
-      { headers: { Authorization: `Bearer ${googleToken}` } },
+    const { messageId } = c.req.param();
+    const { format = "metadata" } = c.req.query();
+    const safeFormat = GMAIL_ALLOWED_FORMATS.has(format) ? format : "metadata";
+
+    const result = await gmailFetch(
+      googleToken,
+      `/users/me/messages/${encodeURIComponent(messageId)}?format=${safeFormat}`,
     );
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    if (!result.ok) {
+      return c.json({ error: `Gmail API error: ${result.status}` }, result.status);
     }
-
-    return c.json(await response.json());
+    return c.json(await result.response.json());
   } catch (error) {
     return c.json({ error: error.message }, 500);
   }
@@ -1094,47 +1096,46 @@ thirdpartyRoutes.get("/gmail/message/:messageId", async (c) => {
  */
 thirdpartyRoutes.get("/gmail/message/:messageId/raw", async (c) => {
   try {
-    const { messageId } = c.req.param();
-
     const googleToken = await getCredential(
       c.env,
       "integrations/google/access_token",
       "GOOGLE_ACCESS_TOKEN",
     );
-
     if (!googleToken) {
       return c.json({ error: "Google access token not configured" }, 503);
     }
 
-    const response = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=raw`,
-      { headers: { Authorization: `Bearer ${googleToken}` } },
-    );
+    const { messageId } = c.req.param();
 
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    const result = await gmailFetch(
+      googleToken,
+      `/users/me/messages/${encodeURIComponent(messageId)}?format=raw`,
+    );
+    if (!result.ok) {
+      return c.json({ error: `Gmail API error: ${result.status}` }, result.status);
     }
 
-    const data = await response.json();
+    const data = await result.response.json();
     if (!data.raw) {
       return c.json({ error: "No raw content in response" }, 404);
     }
 
-    // Gmail returns base64url-encoded RFC 2822 message
-    // Convert base64url → base64 → binary
-    let base64 = data.raw.replace(/-/g, "+").replace(/_/g, "/");
-    while (base64.length % 4) base64 += '=';
-    const binaryString = atob(base64);
+    // Gmail returns base64url-encoded RFC 2822 message (no padding per RFC 4648 §5)
+    // Convert base64url → base64 (+ pad) → binary
+    const b64 = data.raw.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const binaryString = atob(padded);
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {
       bytes[i] = binaryString.charCodeAt(i);
     }
 
+    // Strip non-filename-safe chars from messageId to prevent header injection
+    const safeFilename = messageId.replace(/[^a-zA-Z0-9_\-]/g, "_");
     return new Response(bytes, {
       headers: {
         "Content-Type": "message/rfc822",
-        "Content-Disposition": `attachment; filename="${messageId}.eml"`,
+        "Content-Disposition": `attachment; filename="${safeFilename}.eml"`,
       },
     });
   } catch (error) {

--- a/src/api/routes/thirdparty.js
+++ b/src/api/routes/thirdparty.js
@@ -1123,7 +1123,8 @@ thirdpartyRoutes.get("/gmail/message/:messageId/raw", async (c) => {
 
     // Gmail returns base64url-encoded RFC 2822 message
     // Convert base64url → base64 → binary
-    const base64 = data.raw.replace(/-/g, "+").replace(/_/g, "/");
+    let base64 = data.raw.replace(/-/g, "+").replace(/_/g, "/");
+    while (base64.length % 4) base64 += '=';
     const binaryString = atob(base64);
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {

--- a/src/api/routes/thirdparty.js
+++ b/src/api/routes/thirdparty.js
@@ -1008,4 +1008,137 @@ thirdpartyRoutes.post("/mercury/refresh", async (c, next) => {
   });
 }));
 
+// ── Gmail API Proxy ─────────────────────────────────────────────────
+// Proxies Gmail REST API calls using the same Google OAuth2 token
+// that powers Google Calendar. Requires gmail.readonly scope on the
+// OAuth app (same refresh token rotated by SecretRotationService).
+
+/**
+ * GET /api/thirdparty/gmail/messages
+ * List Gmail messages (metadata only)
+ */
+thirdpartyRoutes.get("/gmail/messages", async (c) => {
+  try {
+    const { q, maxResults = "10", pageToken } = c.req.query();
+
+    const googleToken = await getCredential(
+      c.env,
+      "integrations/google/access_token",
+      "GOOGLE_ACCESS_TOKEN",
+    );
+
+    if (!googleToken) {
+      return c.json({ error: "Google access token not configured" }, 503);
+    }
+
+    const params = new URLSearchParams({ maxResults });
+    if (q) params.append("q", q);
+    if (pageToken) params.append("pageToken", pageToken);
+
+    const response = await fetch(
+      `https://gmail.googleapis.com/gmail/v1/users/me/messages?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${googleToken}` } },
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    }
+
+    return c.json(await response.json());
+  } catch (error) {
+    return c.json({ error: error.message }, 500);
+  }
+});
+
+/**
+ * GET /api/thirdparty/gmail/message/:messageId
+ * Get a single Gmail message (full metadata + snippet)
+ */
+thirdpartyRoutes.get("/gmail/message/:messageId", async (c) => {
+  try {
+    const { messageId } = c.req.param();
+    const { format = "metadata" } = c.req.query();
+
+    const googleToken = await getCredential(
+      c.env,
+      "integrations/google/access_token",
+      "GOOGLE_ACCESS_TOKEN",
+    );
+
+    if (!googleToken) {
+      return c.json({ error: "Google access token not configured" }, 503);
+    }
+
+    const response = await fetch(
+      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=${format}`,
+      { headers: { Authorization: `Bearer ${googleToken}` } },
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    }
+
+    return c.json(await response.json());
+  } catch (error) {
+    return c.json({ error: error.message }, 500);
+  }
+});
+
+/**
+ * GET /api/thirdparty/gmail/message/:messageId/raw
+ * Get raw RFC 2822 .eml bytes for a Gmail message.
+ * Returns the decoded binary (not base64url) with Content-Type: message/rfc822.
+ * This is what chittyevidence-db's backfill endpoint calls.
+ */
+thirdpartyRoutes.get("/gmail/message/:messageId/raw", async (c) => {
+  try {
+    const { messageId } = c.req.param();
+
+    const googleToken = await getCredential(
+      c.env,
+      "integrations/google/access_token",
+      "GOOGLE_ACCESS_TOKEN",
+    );
+
+    if (!googleToken) {
+      return c.json({ error: "Google access token not configured" }, 503);
+    }
+
+    const response = await fetch(
+      `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=raw`,
+      { headers: { Authorization: `Bearer ${googleToken}` } },
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Gmail API error: ${response.status} — ${body}`);
+    }
+
+    const data = await response.json();
+    if (!data.raw) {
+      return c.json({ error: "No raw content in response" }, 404);
+    }
+
+    // Gmail returns base64url-encoded RFC 2822 message
+    // Convert base64url → base64 → binary
+    const base64 = data.raw.replace(/-/g, "+").replace(/_/g, "/");
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    return new Response(bytes, {
+      headers: {
+        "Content-Type": "message/rfc822",
+        "Content-Disposition": `attachment; filename="${messageId}.eml"`,
+      },
+    });
+  } catch (error) {
+    return c.json({ error: error.message }, 500);
+  }
+});
+
 export { thirdpartyRoutes };


### PR DESCRIPTION
## Summary
- Adds 3 Gmail API proxy endpoints under `/api/thirdparty/gmail/*`
- `GET /gmail/messages` — list with query/pagination
- `GET /gmail/message/:messageId` — metadata
- `GET /gmail/message/:messageId/raw` — raw RFC 2822 .eml bytes (decoded from base64url)
- Uses same Google OAuth2 access token as Calendar proxy (auto-rotated by SecretRotationService)
- Required by `chittyevidence-db` Gmail backfill endpoint (`POST /admin/backfill/gmail`)

## Test plan
- [ ] Verify Google OAuth app has `gmail.readonly` scope
- [ ] `curl /api/thirdparty/gmail/messages?maxResults=1` returns message list
- [ ] `curl /api/thirdparty/gmail/message/{id}/raw` returns RFC 2822 content
- [ ] End-to-end: `POST evidence.chitty.cc/admin/backfill/gmail?limit=1&dry=true` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Gmail support: list messages with query/filtering, view message details, and download individual messages in standard (RFC‑822) format
  * Format options for message retrieval (e.g., metadata vs full/raw)

* **Bug Fixes / Reliability**
  * Improved error responses and clearer handling when Gmail access is unavailable or upstream requests fail
<!-- end of auto-generated comment: release notes by coderabbit.ai -->