### PR TITLE
fix(secret-rotation): validate service-account fields and make sub claim optional

### DIFF
--- a/src/services/secret-rotation.js
+++ b/src/services/secret-rotation.js
@@ -223,8 +223,8 @@ export class SecretRotationService {
     }
 
     // Validate and normalize service account fields
-    if (!sa.impersonate || typeof sa.impersonate !== 'string' || sa.impersonate.trim() === '') {
-      return { ok: false, error: 'missing service-account field: impersonate' };
+    if (!sa.client_email || !sa.private_key) {
+      return { ok: false, error: 'missing service-account field: client_email or private_key' };
     }
 
     let normalizedScopes;
@@ -246,12 +246,14 @@ export class SecretRotationService {
     const now = Math.floor(Date.now() / 1000);
     const claims = {
       iss: sa.client_email,
-      sub: sa.impersonate,
       scope: normalizedScopes,
       aud: 'https://oauth2.googleapis.com/token',
       iat: now,
       exp: now + 3600,
     };
+    if (sa.impersonate) {
+      claims.sub = sa.impersonate;
+    }
 
     const signedJwt = await createJwt(claims, sa.private_key);
 


### PR DESCRIPTION
## Summary

Tightens validation in `_rotateViaServiceAccount` (src/services/secret-rotation.js:217) so JWT signing fails fast with clear errors, and relaxes the impersonation requirement so the rotation works for service accounts that don't use domain-wide delegation.

- Return an error if `client_email` or `private_key` is missing from the parsed service-account JSON (needed to sign the JWT at all).
- Keep the missing-`scopes` guard and the array→space-delimited string normalization.
- Drop the hard requirement on `sa.impersonate`; include the `sub` claim only when `sa.impersonate` is set.

## Test plan

- [ ] Unit/manual: parse a service-account JSON with only `client_email`, `private_key`, and `scopes` (array) — rotation proceeds, JWT has no `sub` claim, scopes are space-delimited.
- [ ] Unit/manual: same JSON plus `impersonate` — JWT includes `sub: sa.impersonate`.
- [ ] Unit/manual: missing `client_email` or `private_key` → returns `{ ok: false, error: 'missing service-account field: client_email or private_key' }`.
- [ ] Unit/manual: missing `scopes` → returns `{ ok: false, error: 'missing service-account field: scopes' }`.

https://claude.ai/code/session_01Ne6sKA6sg8SzMk2hZp7WZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ne6sKA6sg8SzMk2hZp7WZs)_