### PR TITLE
fix(google-proxy): isolate non-delegated service-account tokens from Gmail

### DIFF
--- a/src/api/routes/google.js
+++ b/src/api/routes/google.js
@@ -15,6 +15,7 @@
 
 import { Hono } from "hono";
 import { getCredential } from "../../lib/credential-helper.js";
+import { getCachedGDriveToken } from "../../services/secret-rotation.js";
 import { requireServiceToken } from "../../middleware/require-service-token.js";
 
 const googleRoutes = new Hono();
@@ -34,12 +35,10 @@ async function getGoogleToken(env, { scope = "gmail" } = {}) {
   // Fast path: KV-cached rotated token (updated every 50 min)
   if (env.CREDENTIAL_CACHE) {
     try {
-      const delegated = await env.CREDENTIAL_CACHE.get("secret:gdrive:access_token");
-      if (delegated) return delegated;
-      if (scope === "drive") {
-        const appOnly = await env.CREDENTIAL_CACHE.get("secret:gdrive:access_token:app_only");
-        if (appOnly) return appOnly;
-      }
+      const cached = await getCachedGDriveToken(env.CREDENTIAL_CACHE, {
+        allowAppOnly: scope === "drive",
+      });
+      if (cached) return cached;
     } catch {
       console.warn("Google token KV cache read failed; falling back to broker/env token source");
     }

--- a/src/api/routes/google.js
+++ b/src/api/routes/google.js
@@ -26,13 +26,20 @@ const GMAIL_API = "https://www.googleapis.com/gmail/v1/users/me";
 /**
  * Get a valid Google access token — tries KV rotation cache first (fastest),
  * falls back to 1Password broker, then env var.
+ *
+ * scope: "gmail" (default, requires delegated token with a user sub) or "drive"
+ * (accepts a delegated token first, then a non-delegated app-only token).
  */
-async function getGoogleToken(env) {
+async function getGoogleToken(env, { scope = "gmail" } = {}) {
   // Fast path: KV-cached rotated token (updated every 50 min)
   if (env.CREDENTIAL_CACHE) {
     try {
-      const kvToken = await env.CREDENTIAL_CACHE.get("secret:gdrive:access_token");
-      if (kvToken) return kvToken;
+      const delegated = await env.CREDENTIAL_CACHE.get("secret:gdrive:access_token");
+      if (delegated) return delegated;
+      if (scope === "drive") {
+        const appOnly = await env.CREDENTIAL_CACHE.get("secret:gdrive:access_token:app_only");
+        if (appOnly) return appOnly;
+      }
     } catch {
       console.warn("Google token KV cache read failed; falling back to broker/env token source");
     }
@@ -45,8 +52,8 @@ async function getGoogleToken(env) {
 /**
  * Proxy a request to a Google API, injecting the access token.
  */
-async function googleProxy(env, googleUrl) {
-  const token = await getGoogleToken(env);
+async function googleProxy(env, googleUrl, opts = {}) {
+  const token = await getGoogleToken(env, opts);
   if (!token) {
     return { ok: false, status: 503, error: "Google access token not available" };
   }
@@ -90,7 +97,7 @@ googleRoutes.get("/gdrive/files", async (c) => {
   if (pageSize) params.set("pageSize", pageSize);
   if (pageToken) params.set("pageToken", pageToken);
 
-  const result = await googleProxy(c.env, `${DRIVE_API}/files?${params.toString()}`);
+  const result = await googleProxy(c.env, `${DRIVE_API}/files?${params.toString()}`, { scope: "drive" });
   if (!result.ok) return c.json({ error: result.error }, result.status);
   return c.json(result.data);
 });
@@ -107,7 +114,7 @@ googleRoutes.get("/gdrive/files/:fileId", async (c) => {
   if (fields) params.set("fields", fields);
 
   const encodedFileId = encodeURIComponent(fileId);
-  const result = await googleProxy(c.env, `${DRIVE_API}/files/${encodedFileId}?${params.toString()}`);
+  const result = await googleProxy(c.env, `${DRIVE_API}/files/${encodedFileId}?${params.toString()}`, { scope: "drive" });
   if (!result.ok) return c.json({ error: result.error }, result.status);
   return c.json(result.data);
 });
@@ -120,7 +127,7 @@ googleRoutes.get("/gdrive/files/:fileId", async (c) => {
  */
 googleRoutes.get("/gdrive/files/:fileId/content", async (c) => {
   const fileId = c.req.param("fileId");
-  const token = await getGoogleToken(c.env);
+  const token = await getGoogleToken(c.env, { scope: "drive" });
   if (!token) return c.json({ error: "Google access token not available" }, 503);
 
   // First, fetch file metadata to determine mimeType

--- a/src/services/secret-rotation.js
+++ b/src/services/secret-rotation.js
@@ -227,6 +227,14 @@ export class SecretRotationService {
       return { ok: false, error: 'missing service-account field: client_email or private_key' };
     }
 
+    // If impersonate is provided at all, it must be a non-empty string —
+    // an empty/whitespace value would silently cache as app-only and surprise callers.
+    if (sa.impersonate !== undefined && sa.impersonate !== null) {
+      if (typeof sa.impersonate !== 'string' || sa.impersonate.trim() === '') {
+        return { ok: false, error: 'invalid service-account field: impersonate must be a non-empty string when provided' };
+      }
+    }
+
     let normalizedScopes;
     if (!sa.scopes) {
       return { ok: false, error: 'missing service-account field: scopes' };
@@ -282,9 +290,15 @@ export class SecretRotationService {
     const cacheKey = delegated
       ? 'secret:gdrive:access_token'
       : 'secret:gdrive:access_token:app_only';
+    const staleKey = delegated
+      ? 'secret:gdrive:access_token:app_only'
+      : 'secret:gdrive:access_token';
     await this.kv.put(cacheKey, accessToken, {
       expirationTtl: Math.max(expiresIn - 120, 300),
     });
+    // Evict the sibling key so a mode transition (adding/removing impersonate)
+    // doesn't leave a stale token of the other flavor lingering until TTL expiry.
+    await this.kv.delete(staleKey).catch(() => {});
 
     console.log(
       `[SecretRotation] GDrive access token rotated via service_account JWT (${delegated ? 'delegated' : 'app-only'}), expires in ${expiresIn}s`,

--- a/src/services/secret-rotation.js
+++ b/src/services/secret-rotation.js
@@ -275,12 +275,21 @@ export class SecretRotationService {
     const accessToken = data.access_token;
     const expiresIn = data.expires_in || 3600;
 
-    await this.kv.put('secret:gdrive:access_token', accessToken, {
+    // Delegated tokens (with sub) work for Drive and Gmail; non-delegated tokens
+    // only work for Drive — cache them separately so Gmail callers don't pick up
+    // an app-only token and fail against users/me.
+    const delegated = Boolean(claims.sub);
+    const cacheKey = delegated
+      ? 'secret:gdrive:access_token'
+      : 'secret:gdrive:access_token:app_only';
+    await this.kv.put(cacheKey, accessToken, {
       expirationTtl: Math.max(expiresIn - 120, 300),
     });
 
-    console.log(`[SecretRotation] GDrive access token rotated via service_account JWT, expires in ${expiresIn}s`);
-    return { ok: true, expiresIn, method: 'service_account' };
+    console.log(
+      `[SecretRotation] GDrive access token rotated via service_account JWT (${delegated ? 'delegated' : 'app-only'}), expires in ${expiresIn}s`,
+    );
+    return { ok: true, expiresIn, method: 'service_account', delegated };
   }
 
   /**
@@ -366,10 +375,17 @@ export class SecretRotationService {
  * Get a cached GDrive access token (for use by other services).
  *
  * @param {KVNamespace} kv - CREDENTIAL_CACHE binding
+ * @param {{ allowAppOnly?: boolean }} [opts] - When true, falls back to a
+ *   non-delegated (app-only) token that works for Drive but not Gmail.
  * @returns {Promise<string|null>}
  */
-export async function getCachedGDriveToken(kv) {
-  return kv.get('secret:gdrive:access_token');
+export async function getCachedGDriveToken(kv, opts = {}) {
+  const delegated = await kv.get('secret:gdrive:access_token');
+  if (delegated) return delegated;
+  if (opts.allowAppOnly) {
+    return kv.get('secret:gdrive:access_token:app_only');
+  }
+  return null;
 }
 
 /**

--- a/tests/api/google-routes.test.js
+++ b/tests/api/google-routes.test.js
@@ -86,7 +86,7 @@ describe("getGoogleToken token resolution", () => {
   });
 
   it("falls back to getCredential when KV returns null", async () => {
-    env.CREDENTIAL_CACHE.get.mockResolvedValueOnce(null);
+    env.CREDENTIAL_CACHE.get.mockResolvedValue(null);
     mockGetCredential.mockResolvedValueOnce("broker-token");
     globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ files: [] }));
 
@@ -94,6 +94,53 @@ describe("getGoogleToken token resolution", () => {
 
     const [, init] = globalThis.fetch.mock.calls[0];
     expect(init.headers.Authorization).toBe("Bearer broker-token");
+  });
+
+  it("Drive routes fall back to the app-only KV token when delegated is missing", async () => {
+    env.CREDENTIAL_CACHE.get.mockImplementation((key) => {
+      if (key === "secret:gdrive:access_token") return Promise.resolve(null);
+      if (key === "secret:gdrive:access_token:app_only") return Promise.resolve("app-only-tok");
+      return Promise.resolve(null);
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ files: [] }));
+
+    await get("/gdrive/files", env);
+
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer app-only-tok");
+    expect(mockGetCredential).not.toHaveBeenCalled();
+  });
+
+  it("Gmail routes do NOT use the app-only KV token; they fall through to broker/env", async () => {
+    env.CREDENTIAL_CACHE.get.mockImplementation((key) => {
+      if (key === "secret:gdrive:access_token") return Promise.resolve(null);
+      if (key === "secret:gdrive:access_token:app_only") return Promise.resolve("app-only-tok");
+      return Promise.resolve(null);
+    });
+    mockGetCredential.mockResolvedValueOnce("broker-token");
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ messages: [] }));
+
+    await get("/email/messages", env);
+
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer broker-token");
+    expect(mockGetCredential).toHaveBeenCalled();
+    // Ensure the app-only cached token was NOT used.
+    expect(init.headers.Authorization).not.toBe("Bearer app-only-tok");
+  });
+
+  it("Gmail routes prefer the delegated KV token over broker/env", async () => {
+    env.CREDENTIAL_CACHE.get.mockImplementation((key) => {
+      if (key === "secret:gdrive:access_token") return Promise.resolve("delegated-tok");
+      return Promise.resolve(null);
+    });
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ messages: [] }));
+
+    await get("/email/messages", env);
+
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer delegated-tok");
+    expect(mockGetCredential).not.toHaveBeenCalled();
   });
 
   it("falls back to getCredential when CREDENTIAL_CACHE is absent from env", async () => {
@@ -170,7 +217,9 @@ describe("GET /gdrive/files", () => {
     globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ files: [] }));
     await get("/gdrive/files", env, "q=name+contains+'report'");
     const [url] = globalThis.fetch.mock.calls[0];
-    expect(decodeURIComponent(url)).toContain("name contains 'report'");
+    // URLSearchParams serializes spaces as '+', so use form-encoded parsing to read q.
+    const qParam = new URL(url).searchParams.get("q");
+    expect(qParam).toBe("name contains 'report'");
   });
 
   it("forwards fields, pageSize, and pageToken parameters", async () => {

--- a/tests/api/google-routes.test.js
+++ b/tests/api/google-routes.test.js
@@ -338,7 +338,8 @@ describe("GET /gdrive/files/:fileId/content", () => {
   });
 
   it("returns 503 when no token is available", async () => {
-    env.CREDENTIAL_CACHE.get.mockResolvedValueOnce(null);
+    // Override the describe-level default so both delegated and app-only KV lookups miss.
+    env.CREDENTIAL_CACHE.get.mockResolvedValue(null);
     mockGetCredential.mockResolvedValueOnce(undefined);
 
     const res = await get("/gdrive/files/any-id/content", env);

--- a/tests/services/secret-rotation.test.js
+++ b/tests/services/secret-rotation.test.js
@@ -183,33 +183,30 @@ describe("SecretRotationService._rotateViaServiceAccount", () => {
     expect(result.error).toContain("Invalid service_account JSON");
   });
 
-  it("returns error when impersonate field is missing", async () => {
+  it("returns error when client_email is missing", async () => {
+    const sa = { ...VALID_SA };
+    delete sa.client_email;
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("client_email");
+  });
+
+  it("returns error when private_key is missing", async () => {
+    const sa = { ...VALID_SA };
+    delete sa.private_key;
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("private_key");
+  });
+
+  it("omits sub claim when impersonate is absent (app-only token)", async () => {
+    globalThis.fetch = makeFetchOk();
     const sa = { ...VALID_SA };
     delete sa.impersonate;
     const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("impersonate");
-  });
-
-  it("returns error when impersonate is an empty string", async () => {
-    const sa = { ...VALID_SA, impersonate: "" };
-    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("impersonate");
-  });
-
-  it("returns error when impersonate is whitespace-only", async () => {
-    const sa = { ...VALID_SA, impersonate: "   " };
-    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("impersonate");
-  });
-
-  it("returns error when impersonate is not a string", async () => {
-    const sa = { ...VALID_SA, impersonate: 42 };
-    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("impersonate");
+    expect(result.ok).toBe(true);
+    const [[claimsArg]] = mockCreateJwt.mock.calls;
+    expect(claimsArg).not.toHaveProperty("sub");
   });
 
   it("returns error when scopes field is missing", async () => {
@@ -297,20 +294,47 @@ describe("SecretRotationService._rotateViaServiceAccount", () => {
   it("posts JWT-bearer grant_type to Google token endpoint", async () => {
     const mockFetch = makeFetchOk();
     globalThis.fetch = mockFetch;
-
     await service._rotateViaServiceAccount(JSON.stringify(VALID_SA));
-
-    const [url, init] = mockFetch.mock.calls[0];
+    const [[url, init]] = mockFetch.mock.calls;
     expect(url).toBe("https://oauth2.googleapis.com/token");
     expect(init.method).toBe("POST");
-    expect(init.body.toString()).toContain("urn:ietf:params:oauth:grant-type:jwt-bearer");
-    expect(init.body.toString()).toContain("mock.signed.jwt");
+    const params = new URLSearchParams(init.body.toString());
+    expect(params.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+    expect(params.get("assertion")).toBe("mock.signed.jwt");
   });
 
-  it("returns { ok: true, expiresIn, method:'service_account' } on success", async () => {
+  it("returns { ok: true, expiresIn, method:'service_account', delegated } on success", async () => {
     globalThis.fetch = makeFetchOk({ access_token: "new-tok", expires_in: 3600 });
     const result = await service._rotateViaServiceAccount(JSON.stringify(VALID_SA));
-    expect(result).toEqual({ ok: true, expiresIn: 3600, method: "service_account" });
+    expect(result).toEqual({ ok: true, expiresIn: 3600, method: "service_account", delegated: true });
+  });
+
+  it("caches delegated tokens under secret:gdrive:access_token", async () => {
+    globalThis.fetch = makeFetchOk({ access_token: "delegated-tok", expires_in: 3600 });
+    await service._rotateViaServiceAccount(JSON.stringify(VALID_SA));
+    expect(env.CREDENTIAL_CACHE.put).toHaveBeenCalledWith(
+      "secret:gdrive:access_token",
+      "delegated-tok",
+      { expirationTtl: 3480 },
+    );
+  });
+
+  it("caches app-only tokens under secret:gdrive:access_token:app_only when impersonate is absent", async () => {
+    globalThis.fetch = makeFetchOk({ access_token: "app-only-tok", expires_in: 3600 });
+    const sa = { ...VALID_SA };
+    delete sa.impersonate;
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result).toEqual({ ok: true, expiresIn: 3600, method: "service_account", delegated: false });
+    expect(env.CREDENTIAL_CACHE.put).toHaveBeenCalledWith(
+      "secret:gdrive:access_token:app_only",
+      "app-only-tok",
+      { expirationTtl: 3480 },
+    );
+    expect(env.CREDENTIAL_CACHE.put).not.toHaveBeenCalledWith(
+      "secret:gdrive:access_token",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("defaults expiresIn to 3600 when Google response omits expires_in", async () => {

--- a/tests/services/secret-rotation.test.js
+++ b/tests/services/secret-rotation.test.js
@@ -199,6 +199,27 @@ describe("SecretRotationService._rotateViaServiceAccount", () => {
     expect(result.error).toContain("private_key");
   });
 
+  it("returns error when impersonate is an empty string", async () => {
+    const sa = { ...VALID_SA, impersonate: "" };
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("impersonate");
+  });
+
+  it("returns error when impersonate is whitespace-only", async () => {
+    const sa = { ...VALID_SA, impersonate: "   " };
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("impersonate");
+  });
+
+  it("returns error when impersonate is not a string", async () => {
+    const sa = { ...VALID_SA, impersonate: 42 };
+    const result = await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("impersonate");
+  });
+
   it("omits sub claim when impersonate is absent (app-only token)", async () => {
     globalThis.fetch = makeFetchOk();
     const sa = { ...VALID_SA };
@@ -334,6 +355,24 @@ describe("SecretRotationService._rotateViaServiceAccount", () => {
       "secret:gdrive:access_token",
       expect.anything(),
       expect.anything(),
+    );
+  });
+
+  it("evicts the sibling app-only key when rotating a delegated token", async () => {
+    globalThis.fetch = makeFetchOk();
+    await service._rotateViaServiceAccount(JSON.stringify(VALID_SA));
+    expect(env.CREDENTIAL_CACHE.delete).toHaveBeenCalledWith(
+      "secret:gdrive:access_token:app_only",
+    );
+  });
+
+  it("evicts the sibling delegated key when rotating an app-only token", async () => {
+    globalThis.fetch = makeFetchOk();
+    const sa = { ...VALID_SA };
+    delete sa.impersonate;
+    await service._rotateViaServiceAccount(JSON.stringify(sa));
+    expect(env.CREDENTIAL_CACHE.delete).toHaveBeenCalledWith(
+      "secret:gdrive:access_token",
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #165, addressing Codex's P1 concern: with `sub` optional, a non-delegated service-account token was being cached in the shared `secret:gdrive:access_token` key and silently breaking every Gmail proxy call (`users/me` requires delegation) with no fallback.

**Changes:**
- `src/services/secret-rotation.js` — `_rotateViaServiceAccount` now caches delegated tokens under `secret:gdrive:access_token` (unchanged) and non-delegated tokens under a new key `secret:gdrive:access_token:app_only`. The return value includes `delegated: boolean`.
- `src/api/routes/google.js` — `getGoogleToken(env, { scope })` accepts `"gmail"` (default, delegated-only) or `"drive"` (delegated, then app-only). Drive endpoints pass `scope: "drive"`; Gmail endpoints use the default.
- `getCachedGDriveToken(kv, { allowAppOnly })` exposes the same scoping to external callers.
- Updated `tests/services/secret-rotation.test.js` to cover the new validation contract (`client_email`/`private_key` required, `sub` omitted when `impersonate` absent) and the cache-key split. Fixed a pre-existing test that used URL-encoded body matching.
- Updated `tests/api/google-routes.test.js` "no token" test to null-out both KV lookup paths.

## Test plan

- [x] `tests/services/secret-rotation.test.js` — 29/29 pass (new tests assert `app_only` key is used when `impersonate` absent, delegated key otherwise)
- [x] `tests/api/google-routes.test.js` — all route tests pass except one pre-existing unrelated URL-encoding test (`forwards q query parameter`)
- [ ] Manual: rotate a service account without `impersonate`; verify a Drive request succeeds, a Gmail request falls back to broker/env or returns 503 rather than 4xx against a non-delegated token.
- [ ] Manual: rotate a service account with `impersonate`; verify both Drive and Gmail work.

## Notes

The 13 other pre-existing failures on `main` (jwt-helper tests, evidence-search/retrieve via ChittyStorage) are unrelated to this PR and reproduce with these changes reverted.

https://claude.ai/code/session_01Ne6sKA6sg8SzMk2hZp7WZs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ne6sKA6sg8SzMk2hZp7WZs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Google API token handling and caching to ensure more reliable access to Google Drive and Gmail services with better token selection and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->