### PR TITLE
fix(deploy): scope npm run deploy to --env production

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --env production",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
     "kv:seed": "./scripts/seed-kv.sh",
     "test": "vitest",
     "test:watch": "vitest --watch",


### PR DESCRIPTION
## ⚠️ DO NOT ENABLE AUTO-MERGE

This PR's merge will trigger Workers Builds → production deploy. Verify the diff and **manually merge** when ready. The current production worker (`3d46be98`, healthy) is a manual rollback; the moment any commit lands on main, CI re-deploys.

## Summary

`package.json` had `"deploy": "wrangler deploy"` with no `--env` flag. Workers Builds runs that verbatim. Without `--env`, wrangler reads only the top-level config block, where the only declared binding is `secrets_store_secrets`. Every other binding (KV / DO / D1 / R2 / Vectorize / queues / services / AI / Worker Loader / vars / routes / triggers) is correctly scoped under `env.production` per the canonical pattern documented in `wrangler.jsonc:16-20`.

Net effect: every CI deploy produces a worker with 17 secrets and **zero** resource bindings. The runtime tries to use `env.MCP_AGENT` / `env.DB` / `env.OAUTH_KV` / etc, gets `undefined`, and the OAuthProvider chain resolves to non-`Response` — Cloudflare returns 1101 across every path.

This was the regression mechanism for both:
- `c3cd2a6d` (post-PR-#168 deploy, took down prod for ~12h)
- `a48c8f18` (post-PR-#174 deploy from earlier today, also took down prod, rolled back to `3d46be98` via `wrangler rollback`)

Local `wrangler deploy --env production` reads the env block and produces a healthy bundle — same wrangler.jsonc, different invocation, opposite outcomes. The fix is one line of script change; no `wrangler.jsonc` edits needed.

## Diff

```diff
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --env production",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
```

The aliases are belt-and-suspenders: `npm run deploy` always means production now, but explicit `deploy:staging` / `deploy:production` aliases let callers be unambiguous. Revertable in one line if Workers Builds is later configured to use a different command.

## Verification plan (post-merge)

```bash
# 1. Wait for Workers Builds to complete (~30-60s after merge)
npx wrangler deployments list --env production | head -10

# 2. Inspect the new version's bindings — should show ~50 binding lines, not 17
npx wrangler versions view <new_version_id> --env production | tail -80

# 3. Health check
curl -s https://connect.chitty.cc/health | jq .status
# expect: "ok"
```

If the new deploy is broken, `wrangler rollback 3d46be98-344c-4711-9e44-f5418ca84881 --env production` restores the known-good state.

## Why open this with auto-merge disabled

I broke prod once today by letting a merge trigger an auto-deploy from a CI invocation that was structurally wrong. Same root cause that broke prod yesterday after PR #168. Treating this PR as a controlled deploy gate so we observe the next CI build before allowing it to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)