### PR TITLE
feat: standardize mint secret ownership naming to chittyauth-issued

### DIFF
--- a/docs/governance/CREDENTIAL_OWNERSHIP_LAW.md
+++ b/docs/governance/CREDENTIAL_OWNERSHIP_LAW.md
@@ -1,0 +1,41 @@
+# Credential Ownership Law
+
+Canonical URI: `chittycanon://docs/ops/policy/credential-ownership-law`
+
+## Purpose
+
+Define non-overlapping ownership for credential issuance, certificate issuance, key custody, and mint operations across ChittyOS services.
+
+## Binding Rules
+
+1. `chittyauth` is the system of record for API credential issuance and rotation.
+2. `chittymint` consumes credentials for mint operations and does not own cross-service credential lifecycle.
+3. `chittycert` issues and revokes certificates; `chittytrust` evaluates trust and proxies certificate operations.
+4. `chittyid` governs identity format and issuance pipeline policy.
+5. Runtime secret delivery is Cloudflare Secrets Store; source-of-truth remains 1Password.
+
+## Required Naming in ChittyConnect
+
+1. Preferred service auth binding pattern: `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`.
+2. Transitional alias accepted for mint: `MINT_API_KEY`.
+3. Legacy fallback pattern: `CHITTY_<SERVICE>_TOKEN`.
+4. Legacy fallback only for mint webhook compatibility: `CHITTYMINT_SECRET` (deprecated for API auth).
+
+## Enforcement in ChittyConnect
+
+1. Mint auth token resolution order:
+   1. `CHITTYAUTH_ISSUED_MINT_TOKEN`
+   2. `MINT_API_KEY`
+   3. `services/chittymint/service_token` broker path
+   4. `CHITTYMINT_SECRET` (deprecated)
+2. All non-mint service token resolution order:
+   1. `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`
+   2. `services/<service>/service_token` broker path
+   3. `CHITTY_<SERVICE>_TOKEN` (legacy)
+3. Any use of `CHITTYMINT_SECRET` for mint API authorization must emit a deprecation warning.
+
+## Operational Controls
+
+1. Rotate auth-issued mint tokens through `chittyauth` policy.
+2. Propagate rotated values to Cloudflare Secrets Store per environment.
+3. Keep cert issuance and trust attestation out of token issuance workflows.

--- a/docs/governance/CREDENTIAL_OWNERSHIP_LAW.md
+++ b/docs/governance/CREDENTIAL_OWNERSHIP_LAW.md
@@ -9,25 +9,28 @@ Define non-overlapping ownership for credential issuance, certificate issuance, 
 ## Binding Rules
 
 1. `chittyauth` is the system of record for API credential issuance and rotation.
-2. `chittymint` consumes credentials for mint operations and does not own cross-service credential lifecycle.
-3. `chittycert` issues and revokes certificates; `chittytrust` evaluates trust and proxies certificate operations.
-4. `chittyid` governs identity format and issuance pipeline policy.
-5. Runtime secret delivery is Cloudflare Secrets Store; source-of-truth remains 1Password.
+2. `chittycypher` is co-owner for mint secret issuance and key custody workflows.
+3. `chittymint` consumes credentials for mint operations and does not own cross-service credential lifecycle.
+4. `chittycert` issues and revokes certificates; `chittytrust` evaluates trust and proxies certificate operations.
+5. `chittyid` governs identity format and issuance pipeline policy.
+6. Runtime secret delivery is Cloudflare Secrets Store; source-of-truth remains 1Password.
 
 ## Required Naming in ChittyConnect
 
 1. Preferred service auth binding pattern: `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`.
-2. Transitional alias accepted for mint: `MINT_API_KEY`.
-3. Legacy fallback pattern: `CHITTY_<SERVICE>_TOKEN`.
-4. Legacy fallback only for mint webhook compatibility: `CHITTYMINT_SECRET` (deprecated for API auth).
+2. Canonical mint runtime binding: `CHITTYAUTH_ISSUED_MINT_API_KEY`.
+3. Transitional alias accepted for mint: `MINT_API_KEY`.
+4. Legacy fallback pattern: `CHITTY_<SERVICE>_TOKEN`.
+5. Legacy fallback only for mint webhook compatibility: `CHITTYMINT_SECRET` (deprecated for API auth).
 
 ## Enforcement in ChittyConnect
 
 1. Mint auth token resolution order:
-   1. `CHITTYAUTH_ISSUED_MINT_TOKEN`
-   2. `MINT_API_KEY`
-   3. `services/chittymint/service_token` broker path
-   4. `CHITTYMINT_SECRET` (deprecated)
+   1. `CHITTYAUTH_ISSUED_MINT_API_KEY`
+   2. `CHITTYAUTH_ISSUED_MINT_TOKEN`
+   3. `MINT_API_KEY`
+   4. `services/chittymint/service_token` broker path
+   5. `CHITTYMINT_SECRET` (deprecated)
 2. All non-mint service token resolution order:
    1. `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`
    2. `services/<service>/service_token` broker path

--- a/docs/governance/SECRETS_MODEL.md
+++ b/docs/governance/SECRETS_MODEL.md
@@ -25,7 +25,7 @@ Canonical source: `wrangler.jsonc` secrets manifest comments.
 
 | Capability | Owner | Notes |
 |------------|-------|-------|
-| API key/token issuance + rotation | `chittyauth` | Canonical issuer for service credentials |
+| API key/token issuance + rotation | `chittyauth` + `chittycypher` | Canonical issuer and custody authority for service credentials |
 | Certificate issuance/revocation | `chittycert` | CA role |
 | Trust decisioning + cert proxy | `chittytrust` | Policy + proxy, not token issuer |
 | Identity issuance policy | `chittyid` | Pipeline and format governance |
@@ -82,13 +82,15 @@ Pattern: `CHITTY_<SERVICE>_TOKEN`
 | `CHITTY_LEDGER_TOKEN` | ChittyLedger |
 | `CHITTY_ID_SERVICE_TOKEN` | ChittyID generic service token |
 | `CHITTYCONNECT_SERVICE_TOKEN` | ChittyConnect self-service token |
-| `CHITTYMINT_SECRET` | ChittyMint webhook secret |
-| `CHITTYAUTH_ISSUED_MINT_TOKEN` | Preferred auth-issued token for ChittyMint API calls |
+| `CHITTYAUTH_ISSUED_MINT_API_KEY` | Canonical mint API auth token for runtime consumption |
+| `CHITTYAUTH_ISSUED_MINT_TOKEN` | Transitional auth-issued mint alias (one-release shim) |
 | `MINT_API_KEY` | Transitional alias for ChittyMint API auth token |
+| `CHITTYMINT_SECRET` | Legacy ChittyMint webhook secret (not primary API auth) |
 
 Policy:
 - Preferred global pattern: `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`
-- `CHITTYAUTH_ISSUED_MINT_TOKEN` is preferred.
+- `CHITTYAUTH_ISSUED_MINT_API_KEY` is the canonical runtime binding.
+- `CHITTYAUTH_ISSUED_MINT_TOKEN` is a one-release migration alias.
 - `MINT_API_KEY` is allowed during migration.
 - `CHITTYMINT_SECRET` is legacy and should not be primary API auth.
 

--- a/docs/governance/SECRETS_MODEL.md
+++ b/docs/governance/SECRETS_MODEL.md
@@ -21,6 +21,18 @@ Canonical source: `wrangler.jsonc` secrets manifest comments.
 | **KV** | Short-lived rotated values only. Never long-lived secrets. | Ephemeral cache with TTL |
 | **`[vars]`** | Non-secret configuration only. | Per-environment in wrangler.jsonc |
 
+## Ownership Matrix (Normative)
+
+| Capability | Owner | Notes |
+|------------|-------|-------|
+| API key/token issuance + rotation | `chittyauth` | Canonical issuer for service credentials |
+| Certificate issuance/revocation | `chittycert` | CA role |
+| Trust decisioning + cert proxy | `chittytrust` | Policy + proxy, not token issuer |
+| Identity issuance policy | `chittyid` | Pipeline and format governance |
+| Evidence/ID mint operations | `chittymint` | Consumes auth credentials; not issuer |
+
+Reference: [Credential Ownership Law](./CREDENTIAL_OWNERSHIP_LAW.md)
+
 ## Environments
 
 | Environment | Deploy Command | Worker Name |
@@ -71,6 +83,14 @@ Pattern: `CHITTY_<SERVICE>_TOKEN`
 | `CHITTY_ID_SERVICE_TOKEN` | ChittyID generic service token |
 | `CHITTYCONNECT_SERVICE_TOKEN` | ChittyConnect self-service token |
 | `CHITTYMINT_SECRET` | ChittyMint webhook secret |
+| `CHITTYAUTH_ISSUED_MINT_TOKEN` | Preferred auth-issued token for ChittyMint API calls |
+| `MINT_API_KEY` | Transitional alias for ChittyMint API auth token |
+
+Policy:
+- Preferred global pattern: `CHITTYAUTH_ISSUED_<SERVICE>_TOKEN`
+- `CHITTYAUTH_ISSUED_MINT_TOKEN` is preferred.
+- `MINT_API_KEY` is allowed during migration.
+- `CHITTYMINT_SECRET` is legacy and should not be primary API auth.
 
 ### Third-Party Integrations (10)
 

--- a/docs/secrets-ownership.md
+++ b/docs/secrets-ownership.md
@@ -1,0 +1,26 @@
+# ChittyConnect Secrets Ownership
+
+Canonical URI: `chittycanon://docs/ops/policy/secrets-ownership`
+
+## Ownership
+
+| Secret Class | Owner | Notes |
+|---|---|---|
+| `mint_*` and mint API secrets | `chittyauth` + `chittycypher` | Canonical issuer and rotation authority |
+| `cert_*`, TLS cert, signing cert material | `chittytrust` + `chittycert` | Certificate exception class |
+| Runtime delivery to workers | `chittyconnect` | Consumption only, not issuance |
+
+## Canonical Naming Contract
+
+1. Cloudflare Secrets Store key: `chittyauth_issued_mint_api_key`
+2. Runtime env var in services: `CHITTYAUTH_ISSUED_MINT_API_KEY`
+3. Transitional aliases permitted for one release:
+   1. `CHITTYAUTH_ISSUED_MINT_TOKEN`
+   2. `MINT_API_KEY`
+   3. `CHITTYMINT_SECRET` (legacy webhook compatibility only)
+
+## Approval & Rotation Controls
+
+1. Any create/rotate/revoke action requires one approver from secret owner team and one platform reviewer.
+2. Default token rotation interval: 90 days.
+3. Break-glass injections must be logged with issuer, timestamp, expiry, and follow-up rotation ticket.

--- a/src/intelligence/context-resolver.js
+++ b/src/intelligence/context-resolver.js
@@ -526,7 +526,15 @@ export class ContextResolver {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${this.env.CHITTYMINT_SECRET || this.env.CHITTY_ID_TOKEN || ""}`,
+          Authorization: `Bearer ${
+            this.env.CHITTYAUTH_ISSUED_MINT_API_KEY ||
+            this.env.CHITTYAUTH_ISSUED_MINT_TOKEN ||
+            this.env.MINT_API_KEY ||
+            this.env.CHITTYEVIDENCE_MINT_API_KEY ||
+            this.env.CHITTYMINT_SECRET ||
+            this.env.CHITTY_ID_TOKEN ||
+            ""
+          }`,
         },
         body: JSON.stringify(mintBody),
       });

--- a/src/lib/credential-helper.js
+++ b/src/lib/credential-helper.js
@@ -70,6 +70,15 @@ export async function getServiceToken(env, serviceName) {
   }
 
   // Transitional aliases (service-specific).
+  if (normalized === "MINT" && env.CHITTYAUTH_ISSUED_MINT_API_KEY) {
+    return env.CHITTYAUTH_ISSUED_MINT_API_KEY;
+  }
+  if (normalized === "MINT" && env.CHITTYAUTH_ISSUED_MINT_TOKEN) {
+    return env.CHITTYAUTH_ISSUED_MINT_TOKEN;
+  }
+  if (normalized === "MINT" && env.CHITTYEVIDENCE_MINT_API_KEY) {
+    return env.CHITTYEVIDENCE_MINT_API_KEY;
+  }
   if (normalized === "MINT" && env.MINT_API_KEY) {
     return env.MINT_API_KEY;
   }
@@ -92,8 +101,28 @@ export async function getServiceToken(env, serviceName) {
  */
 export async function getMintAuthToken(env) {
   const authIssued =
+    env.CHITTYAUTH_ISSUED_MINT_API_KEY ||
     env.CHITTYAUTH_ISSUED_MINT_TOKEN ||
     env.MINT_API_KEY ||
+    env.CHITTYEVIDENCE_MINT_API_KEY ||
+    await getCredential(
+      env,
+      "services/chittymint/service_token",
+      "CHITTYAUTH_ISSUED_MINT_API_KEY",
+      "chittymint",
+    ) ||
+    await getCredential(
+      env,
+      "services/chittymint/service_token",
+      "CHITTYEVIDENCE_MINT_API_KEY",
+      "chittymint",
+    ) ||
+    await getCredential(
+      env,
+      "services/chittymint/service_token",
+      "CHITTYAUTH_ISSUED_MINT_TOKEN",
+      "chittymint",
+    ) ||
     await getCredential(
       env,
       "services/chittymint/service_token",

--- a/src/lib/credential-helper.js
+++ b/src/lib/credential-helper.js
@@ -60,11 +60,59 @@ export async function getCredential(
  * @returns {Promise<string|undefined>} Service token or undefined
  */
 export async function getServiceToken(env, serviceName) {
-  const tokenEnvVar = `CHITTY_${serviceName.toUpperCase().replace("CHITTY", "")}_TOKEN`;
+  const normalized = serviceName.toUpperCase().replace("CHITTY", "");
+  const authIssuedEnvVar = `CHITTYAUTH_ISSUED_${normalized}_TOKEN`;
+  const legacyEnvVar = `CHITTY_${normalized}_TOKEN`;
+
+  // Prefer ChittyAuth-issued token naming across all services.
+  if (env[authIssuedEnvVar]) {
+    return env[authIssuedEnvVar];
+  }
+
+  // Transitional aliases (service-specific).
+  if (normalized === "MINT" && env.MINT_API_KEY) {
+    return env.MINT_API_KEY;
+  }
+
   return getCredential(
     env,
     `services/${serviceName}/service_token`,
-    tokenEnvVar,
+    legacyEnvVar,
     serviceName,
   );
+}
+
+/**
+ * Resolve auth credential used for ChittyMint API calls.
+ *
+ * Policy:
+ * 1) Prefer ChittyAuth-issued mint token
+ * 2) Fall back to service token for chittymint
+ * 3) Last resort legacy webhook secret (deprecated for API auth)
+ */
+export async function getMintAuthToken(env) {
+  const authIssued =
+    env.CHITTYAUTH_ISSUED_MINT_TOKEN ||
+    env.MINT_API_KEY ||
+    await getCredential(
+      env,
+      "services/chittymint/service_token",
+      "MINT_API_KEY",
+      "chittymint",
+    );
+
+  if (authIssued) {
+    return { token: authIssued, source: "auth-issued" };
+  }
+
+  const serviceToken = await getServiceToken(env, "chittymint");
+  if (serviceToken) {
+    return { token: serviceToken, source: "service-token-fallback" };
+  }
+
+  if (env.CHITTYMINT_SECRET) {
+    return { token: env.CHITTYMINT_SECRET, source: "legacy-webhook-secret" };
+  }
+
+  return { token: undefined, source: "none" };
 }

--- a/src/lib/service-catalog.js
+++ b/src/lib/service-catalog.js
@@ -26,6 +26,7 @@ const SERVICE_ENTRIES = [
   { id: "chittychain", sub: "chain" },
   { id: "chittyledger", sub: "ledger" },
   { id: "chittydispute", sub: "dispute" },
+  { id: "chittyconcierge", sub: "concierge" },
   { id: "chittytrack", sub: "track" },
   { id: "chittytask", sub: "tasks" },
 ];

--- a/src/lib/service-switch.js
+++ b/src/lib/service-switch.js
@@ -19,6 +19,7 @@ const DEFAULTS = {
   id:          { enabled: true, mode: "binding", binding: "SVC_ID" },
   mint:        { enabled: true, mode: "binding", binding: "SVC_ID" },
   evidence:    { enabled: true, mode: "binding", binding: "SVC_EVIDENCE" },
+  concierge:   { enabled: true, mode: "binding", binding: "SVC_CONCIERGE" },
   chronicle:   { enabled: true, mode: "binding", binding: "SVC_CHRONICLE" },
   disputes:    { enabled: true, mode: "binding", binding: "SVC_DISPUTES" },
   score:       { enabled: true, mode: "binding", binding: "SVC_SCORE" },

--- a/src/mcp/tool-dispatcher.js
+++ b/src/mcp/tool-dispatcher.js
@@ -7,7 +7,7 @@
  * @module mcp/tool-dispatcher
  */
 
-import { getCredential, getServiceToken } from "../lib/credential-helper.js";
+import { getCredential, getServiceToken, getMintAuthToken } from "../lib/credential-helper.js";
 import { serviceFetch } from "../lib/service-switch.js";
 import {
   getCloudflareApiCredentials,
@@ -213,10 +213,8 @@ export async function dispatchToolCall(name, args = {}, env, options = {}) {
 
     // ── Identity tools ──────────────────────────────────────────────
     if (name === "chitty_id_mint") {
-      const serviceToken =
-        env.CHITTYMINT_SECRET ||
-        (await getServiceToken(env, "chittymint")) ||
-        (await getServiceToken(env, "chittyid"));
+      const { token: serviceToken, source: mintTokenSource } =
+        await getMintAuthToken(env);
       if (!serviceToken) {
         return {
           content: [
@@ -227,6 +225,11 @@ export async function dispatchToolCall(name, args = {}, env, options = {}) {
           ],
           isError: true,
         };
+      }
+      if (mintTokenSource === "legacy-webhook-secret") {
+        console.warn(
+          "[policy] chitty_id_mint using deprecated CHITTYMINT_SECRET; migrate to CHITTYAUTH_ISSUED_MINT_TOKEN/MINT_API_KEY",
+        );
       }
       const response = await serviceFetch(env, "mint", "/api/mint", {
         method: "POST",

--- a/src/mcp/tool-dispatcher.js
+++ b/src/mcp/tool-dispatcher.js
@@ -228,7 +228,7 @@ export async function dispatchToolCall(name, args = {}, env, options = {}) {
       }
       if (mintTokenSource === "legacy-webhook-secret") {
         console.warn(
-          "[policy] chitty_id_mint using deprecated CHITTYMINT_SECRET; migrate to CHITTYAUTH_ISSUED_MINT_TOKEN/MINT_API_KEY",
+          "[policy] chitty_id_mint using deprecated CHITTYMINT_SECRET; migrate to CHITTYAUTH_ISSUED_MINT_API_KEY (aliases: CHITTYAUTH_ISSUED_MINT_TOKEN, MINT_API_KEY)",
         );
       }
       const response = await serviceFetch(env, "mint", "/api/mint", {

--- a/src/services/cloudflare-secrets-client.js
+++ b/src/services/cloudflare-secrets-client.js
@@ -67,7 +67,8 @@ const PATH_TO_ENV = {
   "services/chittydispute/token": "DISPUTES_API_TOKEN",
   "services/chittytrack/api_token": "API_TOKEN",
   "services/chittytrack/webhook_secret": "GITHUB_WEBHOOK_SECRET",
-  "services/chittymint/secret": "CHITTYMINT_SECRET",
+  "services/chittymint/secret": "CHITTYAUTH_ISSUED_MINT_API_KEY",
+  "services/chittymint/service_token": "CHITTYAUTH_ISSUED_MINT_API_KEY",
 };
 
 export class CloudflareSecretsClient {

--- a/src/services/cloudflare-secrets-client.js
+++ b/src/services/cloudflare-secrets-client.js
@@ -65,7 +65,6 @@ const PATH_TO_ENV = {
   "services/chittychronicle/token": "CHITTY_CHRONICLE_TOKEN",
   "services/chittydispute/service_token": "DISPUTES_API_TOKEN",
   "services/chittydispute/token": "DISPUTES_API_TOKEN",
-  "services/chittydispute/service_token": "DISPUTES_API_TOKEN",
   "services/chittytrack/api_token": "API_TOKEN",
   "services/chittytrack/webhook_secret": "GITHUB_WEBHOOK_SECRET",
   "services/chittymint/secret": "CHITTYMINT_SECRET",

--- a/tests/lib/service-catalog.test.js
+++ b/tests/lib/service-catalog.test.js
@@ -7,7 +7,7 @@ import {
 describe("getServiceCatalog", () => {
   it("returns all services with default domain", () => {
     const catalog = getServiceCatalog({});
-    expect(catalog.length).toBe(19);
+    expect(catalog.length).toBe(20);
     expect(catalog[0]).toHaveProperty("id");
     expect(catalog[0]).toHaveProperty("url");
     expect(catalog[0].url).toMatch(/^https:\/\/.+\.chitty\.cc$/);

--- a/tests/mcp/tool-dispatcher.test.js
+++ b/tests/mcp/tool-dispatcher.test.js
@@ -30,11 +30,13 @@ import { Client } from "@neondatabase/serverless";
 vi.mock("../../src/lib/credential-helper.js", () => ({
   getCredential: vi.fn(),
   getServiceToken: vi.fn(),
+  getMintAuthToken: vi.fn(),
 }));
 
 import {
   getCredential,
   getServiceToken,
+  getMintAuthToken,
 } from "../../src/lib/credential-helper.js";
 
 // Mock global fetch
@@ -109,6 +111,7 @@ const mockEnv = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getMintAuthToken.mockResolvedValue({ token: null, source: "none" });
   neonMocks.connect.mockReset();
   neonMocks.query.mockReset();
   neonMocks.end.mockReset();
@@ -120,7 +123,7 @@ describe("dispatchToolCall", () => {
 
   describe("chitty_id_mint", () => {
     it("returns error when no service token available", async () => {
-      getServiceToken.mockResolvedValue(null);
+      getMintAuthToken.mockResolvedValue({ token: null, source: "none" });
 
       const result = await dispatchToolCall(
         "chitty_id_mint",
@@ -133,6 +136,10 @@ describe("dispatchToolCall", () => {
     });
 
     it("calls ChittyMint service and returns result", async () => {
+      getMintAuthToken.mockResolvedValue({
+        token: "svc-token-123",
+        source: "auth-issued",
+      });
       getServiceToken.mockResolvedValue("svc-token-123");
       mockFetch.mockResolvedValue({
         ok: true,
@@ -163,6 +170,10 @@ describe("dispatchToolCall", () => {
     });
 
     it("returns error on upstream failure", async () => {
+      getMintAuthToken.mockResolvedValue({
+        token: "svc-token-123",
+        source: "auth-issued",
+      });
       getServiceToken.mockResolvedValue("svc-token-123");
       mockFetch.mockResolvedValue({
         ok: false,
@@ -918,6 +929,10 @@ describe("dispatchToolCall", () => {
 
   describe("error handling", () => {
     it("catches fetch exceptions and returns MCP error", async () => {
+      getMintAuthToken.mockResolvedValue({
+        token: "token",
+        source: "auth-issued",
+      });
       getServiceToken.mockResolvedValue("token");
       mockFetch.mockRejectedValue(new Error("Network timeout"));
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -62,8 +62,9 @@
     { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
     { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
     { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
-    { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
-    { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
+    { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+    { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+    { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
       ],
 
   // ──────────────────────────────────────────────────────────────────
@@ -183,8 +184,9 @@
         { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
         { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
         { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
-        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
-        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
+        { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
       ],
       "vars": {
         "ENVIRONMENT": "staging",
@@ -298,8 +300,9 @@
         { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
         { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
         { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
-        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
-        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
+        { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
       ],
 
       "routes": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -61,8 +61,10 @@
     // Mercury OIDC (CF Access SaaS app — programmatic token exchange for write operations)
     { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
     { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
-    { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" }
-  ],
+    { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
+    { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
+    { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
+      ],
 
   // ──────────────────────────────────────────────────────────────────
   // ENVIRONMENTS — one worker, three declared environments
@@ -82,6 +84,8 @@
         "REGISTRY_SERVICE_URL": "https://registry.chitty.cc",
         "CHITTYCHRONICLE_SERVICE_URL": "https://chronicle.chitty.cc",
         "CHITTYMINT_URL": "https://mint.chitty.cc",
+        "CHITTY_MINT_URL": "https://mint.chitty.cc/chittymint/v1/mint-fact",
+        "DOCUMINT_MINT_URL": "https://documint.chitty.cc/documint/v1/mint",
         "CHITTYCONNECT_URL": "http://localhost:8787",
         "CHITTYROUTER_URL": "https://router.chitty.cc",
         "CHITTY_FALLBACK_URL": "https://fallback.id.chitty.cc",
@@ -144,6 +148,7 @@
         { "binding": "SVC_TASKS", "service": "chittyagent-tasks", "environment": "production" },
         { "binding": "SVC_LEDGER", "service": "chittyledger", "environment": "production" },
         { "binding": "SVC_FINANCE", "service": "chittyfinance", "environment": "production" },
+        { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
@@ -177,7 +182,9 @@
         { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE" },
         { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
         { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
-        { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" }
+        { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
+        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
       ],
       "vars": {
         "ENVIRONMENT": "staging",
@@ -186,6 +193,8 @@
         "REGISTRY_SERVICE_URL": "https://registry.chitty.cc",
         "CHITTYCHRONICLE_SERVICE_URL": "https://chronicle.chitty.cc",
         "CHITTYMINT_URL": "https://mint.chitty.cc",
+        "CHITTY_MINT_URL": "https://mint.chitty.cc/chittymint/v1/mint-fact",
+        "DOCUMINT_MINT_URL": "https://documint.chitty.cc/documint/v1/mint",
         "CHITTYCONNECT_URL": "https://chittyconnect-staging.chittyos.workers.dev",
         "CHITTYROUTER_URL": "https://router.chitty.cc",
         "CHITTY_FALLBACK_URL": "https://fallback.id.chitty.cc",
@@ -254,6 +263,7 @@
         { "binding": "SVC_TASKS", "service": "chittyagent-tasks", "environment": "production" },
         { "binding": "SVC_LEDGER", "service": "chittyledger", "environment": "production" },
         { "binding": "SVC_FINANCE", "service": "chittyfinance", "environment": "production" },
+        { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
@@ -287,7 +297,9 @@
         { "binding": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "CF_ACCESS_CLIENT_SECRET_CHITTYFINANCE" },
         { "binding": "MERCURY_OIDC_CLIENT_ID", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_ID" },
         { "binding": "MERCURY_OIDC_CLIENT_SECRET", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_CLIENT_SECRET" },
-        { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" }
+        { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" },
+        { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyevidence_mint_api_key" }
       ],
 
       "routes": [
@@ -301,6 +313,8 @@
         "REGISTRY_SERVICE_URL": "https://registry.chitty.cc",
         "CHITTYCHRONICLE_SERVICE_URL": "https://chronicle.chitty.cc",
         "CHITTYMINT_URL": "https://mint.chitty.cc",
+        "CHITTY_MINT_URL": "https://mint.chitty.cc/chittymint/v1/mint-fact",
+        "DOCUMINT_MINT_URL": "https://documint.chitty.cc/documint/v1/mint",
         "CHITTYCONNECT_URL": "https://connect.chitty.cc",
         "CHITTYROUTER_URL": "https://router.chitty.cc",
         "CHITTY_FALLBACK_URL": "https://fallback.id.chitty.cc",
@@ -372,6 +386,7 @@
         { "binding": "SVC_TASKS", "service": "chittyagent-tasks", "environment": "production" },
         { "binding": "SVC_LEDGER", "service": "chittyledger", "environment": "production" },
         { "binding": "SVC_FINANCE", "service": "chittyfinance", "environment": "production" },
+        { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },


### PR DESCRIPTION
## Summary
- make mint secret authority explicit by standardizing on `chittyauth_issued_mint_api_key` / `CHITTYAUTH_ISSUED_MINT_API_KEY`
- keep migration aliases for one release (`CHITTYAUTH_ISSUED_MINT_TOKEN`, `MINT_API_KEY`, and code fallback from legacy `CHITTYEVIDENCE_MINT_API_KEY`)
- update ChittyConnect docs/governance to codify mint-secret ownership (`chittyauth` + `chittycypher`) and cert exception (`chittytrust` + `chittycert`)
- update wrangler secrets-store bindings and mint auth resolution path

## Validation
- npm test (vitest): 437 passed

## Rollout notes
1. Create secret key `chittyauth_issued_mint_api_key` in secrets store `e914522471964c3c8cf1e601770edcc3`.
2. Keep aliases during this release window.
3. Remove legacy aliases in next release after deploy verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new mint token naming conventions with backward compatibility for legacy naming patterns.
  * Introduced new chittyconcierge service to available services catalog.

* **Documentation**
  * Added comprehensive governance documents defining credential ownership rules, certificate/key custody responsibilities, and secret rotation controls across ChittyOS services.
  * Documented canonical naming contracts and approved transitional aliases for secrets.

* **Bug Fixes**
  * Improved credential resolution with enhanced priority-based fallback chains for service authentication.

* **Chores**
  * Updated deployment configuration with new service bindings and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->