### PR TITLE
feat/secrets portal followups

### DIFF
--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -2,6 +2,30 @@
  * Authentication middleware for ChittyConnect API
  */
 
+function isContextSyncPath(c) {
+  try {
+    const url = new URL(c.req.raw?.url || "http://localhost");
+    return url.pathname === "/api/v1/context/sync";
+  } catch {
+    return false;
+  }
+}
+
+function cfAccessHeadersMatch(c) {
+  const incomingId = c.req.header("CF-Access-Client-Id") || "";
+  const incomingSecret = c.req.header("CF-Access-Client-Secret") || "";
+  const envId = c.env.CHITTY_CF_ACCESS_CLIENT_ID || "";
+  const envSecret = c.env.CHITTY_CF_ACCESS_CLIENT_SECRET || "";
+  return (
+    !!incomingId &&
+    !!incomingSecret &&
+    !!envId &&
+    !!envSecret &&
+    incomingId === envId &&
+    incomingSecret === envSecret
+  );
+}
+
 export async function authenticate(c, next) {
   const authorizationHeader = c.req.header("Authorization") || "";
   const bearerMatch = authorizationHeader.match(/^Bearer\s+(.+)$/i);
@@ -10,6 +34,16 @@ export async function authenticate(c, next) {
   const apiKey = c.req.header("X-ChittyOS-API-Key") || bearerToken;
 
   if (!apiKey) {
+    if (isContextSyncPath(c) && cfAccessHeadersMatch(c)) {
+      c.set("apiKey", {
+        type: "cloudflare-access",
+        name: c.req.header("CF-Access-Authenticated-User-Email") || "unknown",
+        service: "chittycontext-sync",
+        status: "active",
+      });
+      await next();
+      return;
+    }
     return c.json({ error: "Missing API key" }, 401);
   }
 

--- a/src/api/router.js
+++ b/src/api/router.js
@@ -174,6 +174,7 @@ api.all("/api/mercury/*", async (c) => {
 api.route("/api/credentials", credentialsRoutes);
 api.route("/api/intelligence", intelligence);
 api.route("/api/context", contextRoutes);
+api.route("/api/v1/context", contextRoutes);
 api.route("/api/context/tasks", tasksRoutes);
 api.route("/api/files", filesRoutes);
 api.route("/api/dashboard", dashboard);

--- a/src/api/routes/context.js
+++ b/src/api/routes/context.js
@@ -6,6 +6,81 @@ import { Hono } from "hono";
 
 export const contextRoutes = new Hono();
 
+// Ingest a buffered session payload from local daemons (e.g., ch1tty sweep).
+// Body: { type: "SESSION_INGEST", session_id, chitty_id, project, event_count, events, ts, ... }
+contextRoutes.post("/sync", async (c) => {
+  try {
+    const body = await c.req.json();
+    const now = Math.floor(Date.now() / 1000);
+    const type = body?.type || "";
+    const sessionId = body?.session_id || body?.sessionId || null;
+    const chittyId = body?.chitty_id || body?.chittyId || null;
+    const project = body?.project || "unknown";
+    const eventCount = Number(body?.event_count || body?.eventCount || 0);
+
+    if (type !== "SESSION_INGEST" || !sessionId) {
+      return c.json(
+        {
+          ok: false,
+          error: "invalid_request",
+          code: "INVALID_SESSION_INGEST_PAYLOAD",
+        },
+        400,
+      );
+    }
+
+    let eventId = null;
+    if (c.env.DB) {
+      try {
+        eventId = crypto.randomUUID();
+        await c.env.DB.prepare(
+          `
+          INSERT INTO sync_events
+          (event_id, session_id, event_type, source, items_count, bytes_synced, status, synced_at)
+          VALUES (?, ?, 'session_ingest', ?, ?, ?, 'success', ?)
+        `,
+        )
+          .bind(
+            eventId,
+            sessionId,
+            "ch1tty-buffer-sync",
+            eventCount,
+            0,
+            now,
+          )
+          .run();
+      } catch (error) {
+        console.error("[context.sync] D1 sync_events write failed:", error.message);
+      }
+    }
+
+    const sm = c.get("streaming");
+    if (sm) {
+      await sm.broadcast({
+        type: "context.session.ingested",
+        sessionId,
+        chittyId,
+        project,
+        eventCount,
+        eventId,
+      });
+    }
+
+    return c.json({
+      ok: true,
+      accepted: true,
+      eventId,
+      sessionId,
+      eventCount,
+    });
+  } catch (err) {
+    return c.json(
+      { ok: false, error: "bad_json", message: String(err?.message || err) },
+      400,
+    );
+  }
+});
+
 // Set active files for a session
 // Body: { session_id: string, files: [{ uri, name?, size?, sha256?, mime?, metadata? }] }
 contextRoutes.post("/files/set-active", async (c) => {

--- a/src/index.js
+++ b/src/index.js
@@ -2365,6 +2365,29 @@ ${errorInfo.stack}`);
       );
     }
 
+    // Hard guard: some downstream handlers/middleware may accidentally return
+    // undefined/non-Response, which causes Cloudflare to emit 1101
+    // ("Incorrect type for Promise: did not resolve to Response").
+    if (!(response instanceof Response)) {
+      console.error(
+        `[Fetch-Fatal] ${request.method} ${url.pathname} returned non-Response`,
+      );
+      return new Response(
+        JSON.stringify({
+          error: "invalid_handler_response",
+          error_description:
+            "Request handler did not return a valid Response object",
+        }),
+        {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json",
+            ...corsHeaders(request),
+          },
+        },
+      );
+    }
+
     // Debug: log response status for OAuth endpoints
     if (
       url.pathname === "/token" ||

--- a/tests/api/auth-middleware.test.js
+++ b/tests/api/auth-middleware.test.js
@@ -118,4 +118,36 @@ describe("authenticate middleware", () => {
     expect(body.error).toBe("Invalid API key");
     expect(next).not.toHaveBeenCalled();
   });
+
+  it("accepts CF Access client headers for /api/v1/context/sync without API key", async () => {
+    const c = createMockContext({
+      req: {
+        header: headerMap({
+          "CF-Access-Client-Id": "cf-client-id",
+          "CF-Access-Client-Secret": "cf-client-secret",
+          "CF-Access-Authenticated-User-Email": "ops@chitty.cc",
+        }),
+        raw: new Request("http://localhost/api/v1/context/sync", {
+          method: "POST",
+        }),
+      },
+      env: {
+        ...createMockContext().env,
+        CHITTY_CF_ACCESS_CLIENT_ID: "cf-client-id",
+        CHITTY_CF_ACCESS_CLIENT_SECRET: "cf-client-secret",
+      },
+    });
+
+    const next = vi.fn(async () => {});
+    await authenticate(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(c.set).toHaveBeenCalledWith(
+      "apiKey",
+      expect.objectContaining({
+        type: "cloudflare-access",
+        status: "active",
+      }),
+    );
+  });
 });

--- a/tests/api/context-sync-routes.test.js
+++ b/tests/api/context-sync-routes.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import contextRoutes from "../../src/api/routes/context.js";
+import { createMockD1 } from "../helpers/mocks.js";
+
+function makeEnv() {
+  return {
+    DB: createMockD1(),
+  };
+}
+
+describe("context sync routes", () => {
+  it("accepts SESSION_INGEST payloads on /sync", async () => {
+    const env = makeEnv();
+    const req = new Request("http://localhost/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "SESSION_INGEST",
+        session_id: "sess-123",
+        chitty_id: "CID-123",
+        project: "CHITTYOS/chittyconnect",
+        event_count: 4,
+        events: [{ type: "user" }, { type: "assistant" }],
+      }),
+    });
+
+    const res = await contextRoutes.fetch(req, env);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.accepted).toBe(true);
+    expect(body.sessionId).toBe("sess-123");
+  });
+
+  it("rejects invalid sync payloads", async () => {
+    const env = makeEnv();
+    const req = new Request("http://localhost/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "NOT_SESSION_INGEST",
+      }),
+    });
+
+    const res = await contextRoutes.fetch(req, env);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe("INVALID_SESSION_INGEST_PAYLOAD");
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const env = makeEnv();
+    const req = new Request("http://localhost/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{bad-json",
+    });
+
+    const res = await contextRoutes.fetch(req, env);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("bad_json");
+  });
+
+  it("continues when D1 write fails", async () => {
+    const env = makeEnv();
+    env.DB.prepare = vi.fn(() => ({
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockRejectedValue(new Error("d1 unavailable")),
+    }));
+
+    const req = new Request("http://localhost/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "SESSION_INGEST",
+        session_id: "sess-err",
+        event_count: 1,
+      }),
+    });
+
+    const res = await contextRoutes.fetch(req, env);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
- **feat(sync): add context ingest endpoint and CF Access auth path**
- **fix(runtime): guard against non-Response handler returns**
