### PR TITLE
fix(fetch): guard routeAgentRequest result is Response (prod 1101 hotfix)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2325,7 +2325,7 @@ export default {
       // should fall through to the next handler. Throwing means the agent path
       // matched but the DO/fetch failed — return a 500 instead of masking the
       // failure as an unrelated 404 from oauthProvider.
-      agentRouted = agentResponse !== undefined;
+      agentRouted = agentResponse instanceof Response;
     } catch (err) {
       const errorInfo = formatCaughtError(err);
       console.error(


### PR DESCRIPTION
Prod was returning 1101 on every path. Root cause: `routeAgentRequest` from the `agents` package now resolves to Promise<undefined> for non-agent paths; old truthy guard let the Promise return to the runtime → TypeError. Fix: check `instanceof Response`. Hotfix-deployed to prod (75c1d2d4) — /health returns 200. All 442 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request routing logic to more accurately distinguish between handled and unhandled requests, ensuring proper fallback behavior in the request processing pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittyconnect/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->