### PR TITLE
fix(wrangler): remove self-referential script_name on in-worker MCP_AGENT DO binding

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -128,7 +128,7 @@
       ],
       "durable_objects": {
         "bindings": [
-          { "name": "MCP_AGENT", "class_name": "McpConnectAgent", "script_name": "chittyconnect" }
+          { "name": "MCP_AGENT", "class_name": "McpConnectAgent" }
         ]
       },
       "d1_databases": [
@@ -246,6 +246,8 @@
       ],
       "durable_objects": {
         "bindings": [
+          // Staging worker (chittyconnect-staging) binds to the production worker's DO.
+          // Cross-worker DO binding: keep script_name pinned to the prod worker name.
           { "name": "MCP_AGENT", "class_name": "McpConnectAgent", "script_name": "chittyconnect" }
         ]
       },
@@ -373,7 +375,7 @@
       ],
       "durable_objects": {
         "bindings": [
-          { "name": "MCP_AGENT", "class_name": "McpConnectAgent", "script_name": "chittyconnect" }
+          { "name": "MCP_AGENT", "class_name": "McpConnectAgent" }
         ]
       },
       "d1_databases": [


### PR DESCRIPTION
## Summary
Production `connect.chitty.cc/chatgpt/mcp` is returning **500** with `Could not find McpAgent binding for MCP_AGENT`. `/mcp` returns 404. Root cause is a self-referential `script_name: "chittyconnect"` on the in-worker Durable Object binding. Drop the self-reference; keep it on the legit cross-worker staging binding.

## Diagnosis (live)
```
$ curl -sX POST https://connect.chitty.cc/chatgpt/mcp -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{...}}'
{"error":"internal_error",
 "error_description":"Could not find McpAgent binding for MCP_AGENT. Did you update your wrangler configuration?"}

$ curl -sX POST https://connect.chitty.cc/mcp -H ...
404 Not Found
```

## Why
Code is fine: `McpConnectAgent` is exported (`src/index.js:2510`), extends `McpAgent`, and migration v4 (`wrangler.jsonc:34`) declares it as `new_sqlite_classes`. The bug is in the binding shape — for an in-worker DO, omit `script_name`. With `script_name: "chittyconnect"` on the prod worker (itself `chittyconnect`), the agents-sdk loader treats it as an external cross-script binding and fails to resolve.

## Changes (`wrangler.jsonc`)
- **dev env (line 131)**: drop self-referential `script_name`
- **production env (line 378)**: drop self-referential `script_name`
- **staging env (line 251)**: keep `script_name="chittyconnect"` (legit cross-worker — `chittyconnect-staging` binds prod's DO state); added comment

## Test plan
- [x] `wrangler deploy --env production --dry-run` accepts config
- [ ] Deploy to staging: `npm run deploy:staging`
- [ ] Smoke: `curl -X POST https://connect-staging.chitty.cc/chatgpt/mcp` returns valid JSON-RPC `initialize` response (not 500)
- [ ] Smoke: `curl -X POST https://connect-staging.chitty.cc/mcp` returns valid JSON-RPC `initialize` response (not 404)
- [ ] Deploy to production: `npm run deploy:production`
- [ ] Re-verify both endpoints on `connect.chitty.cc`
- [ ] Optional: run `tests/contracts/get-registry-auth.contract.test.js` and any MCP contract test with `RUN_LIVE_CONTRACT_TESTS=1`

## Risk
Low. Single-line config change per env, no code change, validated by wrangler dry-run. DO state on prod is unaffected — same `class_name`, same binding name, same migration history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)