### PR TITLE
chore(chatgpt-mcp): add Deprecation/Sunset headers — retire to mcp.chitty.cc

### DIFF
--- a/src/api/routes/chatgpt-mcp.js
+++ b/src/api/routes/chatgpt-mcp.js
@@ -23,6 +23,20 @@ const mcpHandler = McpConnectAgent.serve("/chatgpt/mcp", {
   binding: "MCP_AGENT",
 });
 
+// Deprecation headers — this route is being retired in favor of the canonical
+// mcp.chitty.cc aggregator. ChatGPT clients should re-register against
+// https://mcp.chitty.cc/ (unified OAuth, same scopes, same tools, unified audit).
+// Sunset window: 2026-08-15.
+chatgptMcp.use("*", async (c, next) => {
+  await next();
+  c.header("Deprecation", "true");
+  c.header("Sunset", "Sat, 15 Aug 2026 00:00:00 GMT");
+  c.header(
+    "Link",
+    '<https://mcp.chitty.cc/mcp>; rel="successor-version", <https://mcp.chitty.cc/sse>; rel="alternate"',
+  );
+});
+
 /**
  * Authentication middleware.
  * Extracts bearer token or API key. Validation is deferred to the DO layer

--- a/src/api/routes/chatgpt-mcp.js
+++ b/src/api/routes/chatgpt-mcp.js
@@ -29,12 +29,20 @@ const mcpHandler = McpConnectAgent.serve("/chatgpt/mcp", {
 // Sunset window: 2026-08-15.
 chatgptMcp.use("*", async (c, next) => {
   await next();
-  c.header("Deprecation", "true");
-  c.header("Sunset", "Sat, 15 Aug 2026 00:00:00 GMT");
-  c.header(
+  // The downstream MCP handler returns a streamed Response (SSE) whose headers
+  // are immutable; mutating c.res.headers in place can throw. Rebuild the
+  // Response so deprecation headers attach cleanly without buffering the body.
+  const res = new Response(c.res.body, c.res);
+  // RFC 9745: Deprecation is a structured-field Date (@<unix-seconds>), not a
+  // boolean. @1778976000 = 2026-05-17T00:00:00Z, the date this route entered
+  // deprecation.
+  res.headers.set("Deprecation", "@1778976000");
+  res.headers.set("Sunset", "Sat, 15 Aug 2026 00:00:00 GMT");
+  res.headers.set(
     "Link",
     '<https://mcp.chitty.cc/mcp>; rel="successor-version", <https://mcp.chitty.cc/sse>; rel="alternate"',
   );
+  c.res = res;
 });
 
 /**


### PR DESCRIPTION
Companion to chittyos/chittymcp#66.

Adds standard deprecation signals on every response from `connect.chitty.cc/chatgpt/mcp`:
```
Deprecation: true
Sunset: Sat, 15 Aug 2026 00:00:00 GMT
Link: <https://mcp.chitty.cc/mcp>; rel="successor-version",
      <https://mcp.chitty.cc/sse>; rel="alternate"
```

ChatGPT MCP doesn't require a unique hostname or carve-out — the OpenAI spec only needs a valid OAuth issuer + MCP transport, both already on the canonical `mcp.chitty.cc` aggregator.

After sunset (2026-08-15), the McpConnectAgent + `/chatgpt/mcp` route + `api/routes/chatgpt-mcp.js` handler should be removed from chittyconnect entirely.