### PR TITLE
fix(secrets): drop dead CHITTYEVIDENCE_MINT_API_KEY refs; remap chittyid alias

### DIFF
--- a/src/intelligence/context-resolver.js
+++ b/src/intelligence/context-resolver.js
@@ -530,7 +530,6 @@ export class ContextResolver {
             this.env.CHITTYAUTH_ISSUED_MINT_API_KEY ||
             this.env.CHITTYAUTH_ISSUED_MINT_TOKEN ||
             this.env.MINT_API_KEY ||
-            this.env.CHITTYEVIDENCE_MINT_API_KEY ||
             this.env.CHITTYMINT_SECRET ||
             this.env.CHITTY_ID_TOKEN ||
             ""

--- a/src/lib/credential-helper.js
+++ b/src/lib/credential-helper.js
@@ -76,9 +76,6 @@ export async function getServiceToken(env, serviceName) {
   if (normalized === "MINT" && env.CHITTYAUTH_ISSUED_MINT_TOKEN) {
     return env.CHITTYAUTH_ISSUED_MINT_TOKEN;
   }
-  if (normalized === "MINT" && env.CHITTYEVIDENCE_MINT_API_KEY) {
-    return env.CHITTYEVIDENCE_MINT_API_KEY;
-  }
   if (normalized === "MINT" && env.MINT_API_KEY) {
     return env.MINT_API_KEY;
   }
@@ -104,17 +101,10 @@ export async function getMintAuthToken(env) {
     env.CHITTYAUTH_ISSUED_MINT_API_KEY ||
     env.CHITTYAUTH_ISSUED_MINT_TOKEN ||
     env.MINT_API_KEY ||
-    env.CHITTYEVIDENCE_MINT_API_KEY ||
     await getCredential(
       env,
       "services/chittymint/service_token",
       "CHITTYAUTH_ISSUED_MINT_API_KEY",
-      "chittymint",
-    ) ||
-    await getCredential(
-      env,
-      "services/chittymint/service_token",
-      "CHITTYEVIDENCE_MINT_API_KEY",
       "chittymint",
     ) ||
     await getCredential(

--- a/src/services/cloudflare-secrets-client.js
+++ b/src/services/cloudflare-secrets-client.js
@@ -53,7 +53,7 @@ const PATH_TO_ENV = {
   "services/chittyauth/auth_salt": "AUTH_SALT",
   "services/chittyconnect/service_token": "CHITTYCONNECT_SERVICE_TOKEN",
   "services/chittyconnect/mcp_token": "CHITTYCONNECT_TOKEN",
-  "services/chittyid/service_token": "CHITTY_ID_SERVICE_TOKEN",
+  "services/chittyid/service_token": "CHITTY_ID_TOKEN",
   "services/chittyid/token": "CHITTY_ID_TOKEN",
   "services/chittyregistry/token": "CHITTY_REGISTRY_TOKEN",
   "services/chittyregistry/service_token": "CHITTY_REGISTRY_SERVICE_TOKEN",


### PR DESCRIPTION
## Summary
- Drops `CHITTYEVIDENCE_MINT_API_KEY` from mint auth fallback chains in `credential-helper.js` and `context-resolver.js` — env var is never bound in `wrangler.jsonc`, so the references were dead code that suggested a binding exists when it doesn't.
- Remaps `services/chittyid/service_token` → `CHITTY_ID_TOKEN` in `cloudflare-secrets-client.js` PATH_TO_ENV. The prior value (`CHITTY_ID_SERVICE_TOKEN`) is a retired env name per the wrangler secrets manifest comment block.

## Why
Triaged from the 2026-03-16 wrangler audit re-run against current HEAD. Both items were real findings (after correcting earlier false claims about env blocks and MCP_AGENT DO declarations).

## Test plan
- [x] `npm test` — 442 passed, 1 skipped (contract test requires auth)
- [ ] CI green on PR
- [ ] Post-deploy smoke: mint via `getMintAuthToken(env)` still resolves through remaining aliases (`CHITTYAUTH_ISSUED_MINT_API_KEY` / `_TOKEN` / `MINT_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined credential and token resolution logic across authentication components to improve code maintainability and remove deprecated fallback options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittyconnect/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->