### PR TITLE
feat(doctrine): distribute orchestrator directive via public doctrine seed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -466,6 +466,16 @@ app.get("/api/v1/doctrine/seed", (c) => {
       recall_memory: "POST /api/v1/memory/recall",
       doctrine_seed: "GET /api/v1/doctrine/seed",
     },
+
+    // Standing orchestrator-mode directive, distributed globally via the public
+    // doctrine seed. Consumers (e.g. ch1tty SessionStart hooks) cache .text and
+    // inject it each session. sha256 covers the exact UTF-8 bytes of .text.
+    orchestrator_directive: {
+      version: "1.0.0",
+      sha256:
+        "3c82749eccce0420fe2effd0e4a3279d3499a7a334c2a5b578f75ec00cdb9d86",
+      text: "ORCHESTRATOR MODE (binding): You are the brain/manager/strategist/evaluator, not the worker. Delegate workstreams to subagents / ch1tty cast+alchemist / orchestrator MCP / ChittyConnect rather than hand-coding serially. Spin plates, don't spin yourself. Persist taskboard + workstream state to durable backends (ChittyTasks Neon queue or Notion), never session-local only. For multi-step efforts that must survive a crash, register a remote /schedule routine that reclaims from the durable board. Use /reclaim for orphan tasks. Before doing anything yourself, ask which agent/system/durable store owns it.",
+    },
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `orchestrator_directive { version, text, sha256 }` to the PUBLIC `GET /api/v1/doctrine/seed` response (no auth, no secret).
- The standing ORCHESTRATOR MODE directive now rides the global doctrine seed; ch1tty SessionStart hooks cache `.text` to `~/.ch1tty/canon/cache/orchestrator-directive.txt`, with embedded heredoc fallback.
- `sha256` covers the exact UTF-8 bytes of `.text` (len=605, byte-identical to the local hook heredoc): `3c82749eccce0420fe2effd0e4a3279d3499a7a334c2a5b578f75ec00cdb9d86`.

## Deploy blocker (needs operator action — NOT introduced by this PR)
`wrangler deploy --env production` fails with a pre-existing binding error, independent of this one-field change:

```
Service binding 'SVC_EVIDENCE' references environment 'production' on Worker
'chittyevidence' which was not found. [code: 10144]
```

Root cause: wrangler.jsonc binds SVC_EVIDENCE -> service "chittyevidence", environment "production", but the deployed evidence worker is named chittyevidence-db with no named production env. Neither name nor env matches a live worker. This blocks every connect deploy. Resolution (rename binding to chittyevidence-db + drop environment field, or deploy a chittyevidence prod env) is left to the operator to avoid altering service wiring.

## Test plan
- [ ] Resolve the SVC_EVIDENCE binding drift, then wrangler deploy --env production.
- [ ] curl -s https://connect.chitty.cc/api/v1/doctrine/seed | jq '.orchestrator_directive.version, (.orchestrator_directive.text|length)' -> "1.0.0", 605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now includes orchestrator mode with work delegation to subagents and durable routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittyconnect/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->