### PR TITLE
fix: SVC_EVIDENCE binding drift + recall 500 + orchestrator directive (#206 #207 #205)

### DIFF
--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -47,7 +47,17 @@ export async function authenticate(c, next) {
     return c.json({ error: "Missing API key" }, 401);
   }
 
-  // Validate API key against KV store
+  // Validate API key against KV store. Guard against a missing binding so a
+  // deploy-time binding drift surfaces as a clear 503 rather than a raw 500
+  // TypeError ("Cannot read properties of undefined (reading 'get')").
+  // See chittyos/chittyconnect#207.
+  if (!c.env.API_KEYS || typeof c.env.API_KEYS.get !== "function") {
+    console.error("[auth] API_KEYS KV binding is missing");
+    return c.json(
+      { error: "Auth backend unavailable", code: "API_KEYS_BINDING_MISSING" },
+      503,
+    );
+  }
   const keyData = await c.env.API_KEYS.get(`key:${apiKey}`);
 
   // OAuth MCP flow passes bearer access tokens (not API keys). For requests

--- a/src/index.js
+++ b/src/index.js
@@ -483,6 +483,16 @@ app.get("/api/v1/doctrine/seed", (c) => {
       recall_memory: "POST /api/v1/memory/recall",
       doctrine_seed: "GET /api/v1/doctrine/seed",
     },
+
+    // Standing orchestrator-mode directive, distributed globally via the public
+    // doctrine seed. Consumers (e.g. ch1tty SessionStart hooks) cache .text and
+    // inject it each session. sha256 covers the exact UTF-8 bytes of .text.
+    orchestrator_directive: {
+      version: "1.0.0",
+      sha256:
+        "3c82749eccce0420fe2effd0e4a3279d3499a7a334c2a5b578f75ec00cdb9d86",
+      text: "ORCHESTRATOR MODE (binding): You are the brain/manager/strategist/evaluator, not the worker. Delegate workstreams to subagents / ch1tty cast+alchemist / orchestrator MCP / ChittyConnect rather than hand-coding serially. Spin plates, don't spin yourself. Persist taskboard + workstream state to durable backends (ChittyTasks Neon queue or Notion), never session-local only. For multi-step efforts that must survive a crash, register a remote /schedule routine that reclaims from the durable board. Use /reclaim for orphan tasks. Before doing anything yourself, ask which agent/system/durable store owns it.",
+    },
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,25 @@ async function ensureEcosystemInitialized(env) {
       "[ChittyConnect] Initializing ChittyOS ecosystem integration...",
     );
 
-    // Initialize D1 database schema (critical)
-    await initializeDatabase(env.DB);
+    // Initialize D1 database schema. Non-fatal: if the DB binding is
+    // missing/broken (e.g. a deploy lag where the live worker pre-dates the
+    // current bindings) we must NOT poison the entire ecosystem init —
+    // otherwise every authenticated route returns a raw 500 instead of the
+    // 503/JSON envelope the handlers expect. See chittyos/chittyconnect#207.
+    if (env.DB && typeof env.DB.prepare === "function") {
+      try {
+        await initializeDatabase(env.DB);
+      } catch (err) {
+        console.warn(
+          "[ChittyConnect] initializeDatabase failed (continuing):",
+          err?.message || err,
+        );
+      }
+    } else {
+      console.warn(
+        "[ChittyConnect] env.DB binding missing or invalid; skipping schema init",
+      );
+    }
 
     // Initialize intelligence modules
     console.log("[ChittyConnect] Initializing intelligence modules...");

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -152,7 +152,7 @@
         { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
-        { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
+        { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
@@ -272,7 +272,7 @@
         { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
-        { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
+        { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
@@ -400,7 +400,7 @@
         { "binding": "SVC_CONCIERGE", "service": "chittyconcierge", "environment": "production" },
         { "binding": "SVC_CONTEXTUAL", "service": "chittycontextual", "environment": "production" },
         { "binding": "SVC_ID", "service": "chittyid", "environment": "production" },
-        { "binding": "SVC_EVIDENCE", "service": "chittyevidence", "environment": "production" },
+        { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
         { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },


### PR DESCRIPTION
## Summary

Unblocks ChittyConnect production deploys and ships the orchestrator-directive distribution rail in a single change. Combines the fixes for #206 and #207 with the previously-coded #205.

- **#206** — `SVC_EVIDENCE` service binding pointed at a worker (`chittyevidence` env `production`) that does not exist. Live deployed worker is `chittyevidence-db` (default environment). Rebind across dev/staging/production blocks. Verified via Cloudflare API — `chittyevidence-db` exists with `default_environment.environment="production"`, `chittyevidence` returns `code 10007 / "This Worker does not exist on your account"`. Eliminates `wrangler` error 10144 that has blocked every production deploy since #142.
- **#207** — `POST /memory/recall` (and every other authenticated POST route) returned a raw 500 "Internal Server Error". Root cause: the currently-deployed worker is missing all KV/D1/AI/service bindings (collateral damage from the #206 deploy block — the most recent successful deploy was 2026-05-18, before later binding additions landed in `wrangler.jsonc`). Two cascading `TypeError`s fired before any handler body:
  1. `env.DB.prepare` — `initializeDatabase` threw inside `ensureEcosystemInitialized`, leaving `intelligenceModules = null`.
  2. `env.API_KEYS.get` — authentication middleware crashed with `Cannot read properties of undefined (reading 'get')` on every authenticated route.
  Confirmed by live `wrangler tail chittyconnect`:
  ```
  (log)   [ChittyConnect] Initializing ChittyOS ecosystem integration...
  (error) [ChittyConnect] Initialization error: TypeError: Cannot read properties of undefined (reading 'prepare')
  (log)   <-- POST /api/v1/memory/recall
  (error) TypeError: Cannot read properties of undefined (reading 'get')
  (log)   --> POST /api/v1/memory/recall 500 0ms
  ```
  Both root causes resolve as soon as a successful production deploy lands (env.DB / env.API_KEYS are declared in `wrangler.jsonc`). The guards added here are defense-in-depth so a future binding drift surfaces as a structured 503 with a JSON envelope instead of a raw 500.
- **#205** — public `doctrine/seed` now distributes `orchestrator_directive { version, sha256, text }`. Carried over from the previous PR (commit `cb6a26d`) so a single deploy ships everything.

## Test plan

- [x] All 442 unit/integration tests pass (`npm test`)
- [x] `wrangler deploy --env production --dry-run` succeeds
- [ ] Post-deploy: `GET /api/v1/doctrine/seed` includes `orchestrator_directive` with version `1.0.0`, sha `3c82749…`, len 605
- [ ] Post-deploy: `POST /api/v1/memory/recall` with bearer auth returns 200 (not 500)
- [ ] Post-deploy: viewport-hydration hook reports real memory, not "status 500"

Closes #205
Closes #206
Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)