### PR TITLE
fix(wrangler): rebind SVC_SCORE to chittyscore-worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -155,7 +155,7 @@
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
-        { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
+        { "binding": "SVC_SCORE", "service": "chittyscore-worker" },
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     },
@@ -275,7 +275,7 @@
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
-        { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
+        { "binding": "SVC_SCORE", "service": "chittyscore-worker" },
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     },
@@ -403,7 +403,7 @@
         { "binding": "SVC_EVIDENCE", "service": "chittyevidence-db" },
         { "binding": "SVC_CHRONICLE", "service": "chittychronicle", "environment": "production" },
         // { "binding": "SVC_DISPUTE", "service": "chittydispute" },  // TODO: uncomment to use service-binding instead of HTTPS fetch to dispute.chitty.cc
-        { "binding": "SVC_SCORE", "service": "chittyscore", "environment": "production" },
+        { "binding": "SVC_SCORE", "service": "chittyscore-worker" },
         { "binding": "SVC_STORAGE", "service": "chittystorage" }
       ]
     }


### PR DESCRIPTION
## Summary

Follow-on to #212. After that deploy was attempted, production blocked on the same class of binding drift but on a different target:

\`\`\`
Service binding 'SVC_SCORE' references environment 'production' on Worker 'chittyscore' which was not found. [code: 10144]
\`\`\`

The actual deployed worker is \`chittyscore-worker\` (default environment), not \`chittyscore\`. Verified via the Cloudflare API. Rebind across dev/staging/production blocks, drop the \`environment\` qualifier — matches the live target.

This change is already deployed (production version \`21072dbb-1633-40b8-9f4a-f03bdb00ac75\`); merging brings main back into sync with the deployed config.

## Test plan

- [x] \`wrangler deploy --env production\` succeeded
- [x] \`GET /api/v1/doctrine/seed\` returns orchestrator_directive with sha \`3c82749…\`, len 605
- [x] \`POST /api/v1/memory/recall\` no longer returns raw 500; returns structured JSON envelope on auth failure