### PR TITLE
fix(deploy): build.command guard blocks bare wrangler deploy (#219)

### DIFF
--- a/scripts/safe-deploy.sh
+++ b/scripts/safe-deploy.sh
@@ -68,8 +68,10 @@ fi
 echo "[safe-deploy] env=$ENV worker=$DEPLOYED_NAME"
 
 # ── 1. Deploy with explicit --env ────────────────────────────────────────────
+# CHITTYCONNECT_SAFE_DEPLOY=1 is required by wrangler.jsonc's build.command
+# guard (#219). Without it, wrangler aborts before writing any binding.
 echo "[safe-deploy] running: npx wrangler deploy --env $ENV"
-npx wrangler deploy --env "$ENV"
+CHITTYCONNECT_SAFE_DEPLOY=1 npx wrangler deploy --env "$ENV"
 
 # ── 2. Audit declared vs attached bindings ───────────────────────────────────
 echo "[safe-deploy] auditing bindings on live worker $DEPLOYED_NAME ..."

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,7 +27,20 @@
   "account_id": "0bc21e3a5a9de1a4cc843be9c3e98121",
 
   "observability": { "enabled": true },
-  "build": { "command": "", "cwd": "." },
+
+  // ──────────────────────────────────────────────────────────────────
+  // BARE DEPLOY GUARD (#219)
+  // wrangler runs build.command before every deploy. We require a
+  // sentinel env var that scripts/safe-deploy.sh sets — so bare
+  // `wrangler deploy` invocations (no --env, no wrapper) abort here
+  // before any binding write happens. Catches: laptop shells with the
+  // Global API Key, wdeploy-style aliases, agent scripts, stray CI.
+  // The only sanctioned deploy path is `npm run deploy[:staging]`.
+  // ──────────────────────────────────────────────────────────────────
+  "build": {
+    "command": "case \"$WRANGLER_COMMAND\" in deploy|versions) [ \"$CHITTYCONNECT_SAFE_DEPLOY\" = \"1\" ] || { echo '::error::wrangler '\"$WRANGLER_COMMAND\"' was invoked outside scripts/safe-deploy.sh — refusing. Run `npm run deploy` (or `npm run deploy:staging`) instead. See chittyconnect#219.' >&2; exit 1; } ;; esac",
+    "cwd": "."
+  },
 
   // Migrations are global to the DO class, not per-env
   "migrations": [


### PR DESCRIPTION
Closes #219.

## Summary
- `wrangler.jsonc:build.command` now refuses any `wrangler deploy` / `versions upload` invocation that lacks `CHITTYCONNECT_SAFE_DEPLOY=1`.
- `scripts/safe-deploy.sh` exports the sentinel before invoking wrangler — `npm run deploy[:staging]` is the only path that passes the guard.
- `wrangler dev`, `wrangler types`, and other non-deploy subcommands are unaffected (matched by `WRANGLER_COMMAND` in build.command).

## Why this and not other approaches
- **Rename top-level `name` to a sentinel** — breaks `safe-deploy.sh` line 61 (`WORKER_NAME` powers both the staging suffix and the CF API audit path). Rejected.
- **Block via GHA only** — the CF audit log shows the recent wipes came from `nick@chittycorp.com` (Global API Key), not a workflow's `CLOUDFLARE_API_TOKEN`. GHA-side blocks miss the actual vector. The build.command guard fires inside wrangler itself, so it catches laptop shells, aliases, and stray agents — same defense regardless of caller.

## Investigation findings (full report in #219 thread)
Searched for active wipe vectors across both ChittyOS orgs and this VM:
- **No active default-branch workflow in any ChittyOS / ChittyFoundation repo deploys to the chittyconnect worker** outside of `chittyos/chittyconnect/.github/workflows/deploy.yml`. Other repos' bare `wrangler deploy` workflows (chittymonitor, chittyrouter, chittyscrape) target their own worker names — verified against their wrangler configs.
- One stale workflow in `chittyos/chittyos-workspace` (`deploy-chittyconnect.yml`) exists only on a non-default branch; never run successfully. Cleanup PR coming separately.
- No `wrangler deploy` cron / systemd timer on chittyserv-vm.
- No agent scripts under `~/.claude`, `~/.ops`, `~/.ch1tty` invoke wrangler against connect.
- Wipes originate off this VM — likely a personal shell with the `wdeploy` alias from `chittyos-workspace/CHITTYOS/chittyos-terminal-setup.sh:71` sourced, or `cd $duplicate_clone && wrangler deploy`. The Global API Key in env is what gives those invocations blanket deploy authority.

## Test plan
- [x] `wrangler deploy --env production --dry-run` → BLOCKS with guard error pointing at #219.
- [x] `CHITTYCONNECT_SAFE_DEPLOY=1 wrangler deploy --env production --dry-run` → proceeds, full bindings shown, `--dry-run: exiting now.`.
- [x] `wrangler dev` → unaffected.
- [ ] On merge: confirm `Deploy to Cloudflare` GHA workflow still passes (it runs `npm run deploy:production` → safe-deploy.sh → sentinel).
- [ ] On merge: binding-audit cron stays green.

## Follow-ups (separate issues / PRs)
1. **Workspace cleanup** — kill `wdeploy` alias + `cc.deploy`/`rtr.deploy` aliases + duplicate `chittyos-apps/chittyconnect/wrangler.toml` in `chittyos/chittyos-workspace`. PR coming.
2. **Org-wide Global API Key rotation** — `nick@chittycorp.com` Global API Key gives blanket deploy authority over every worker in account `0bc21e3a5a9de1a4cc843be9c3e98121`. Recommend rotating to per-worker scoped tokens. To be filed separately; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)