### PR TITLE
feat(git): tenant allowlists for repo/remote/author + CF gateway tags

### DIFF
--- a/migrations/018_git_tenant_allowlists.sql
+++ b/migrations/018_git_tenant_allowlists.sql
@@ -1,0 +1,92 @@
+-- 018_git_tenant_allowlists.sql — Per-tenant policy for the Git Tool Surface
+--
+-- Implements chittyos/chittyconnect#211 per the Git Tool Surface in CHARTER.md
+-- (see "Policy gates"):
+--   - Remote allowlist  → which `remote_url` patterns a tenant may push to
+--   - Repo allowlist    → which absolute `repo_path` prefixes are readable/writable
+--   - Author allowlist  → which `author` identities a tenant may commit as
+--   - CF gateway tag    → controls surface membership (chittymcp + ch1tty include,
+--                         chittymsg excludes) for the chittyagent-git upstream
+--
+-- Tenant rows in `tenant_projects` (016_tenant_registry.sql) are the parent.
+-- These tables are independent per-tenant policy; a tenant with no rows in
+-- `git_remote_allowlist` cannot push anywhere (fail-closed default).
+
+CREATE TABLE IF NOT EXISTS git_remote_allowlist (
+  tenant_id       TEXT NOT NULL,
+  pattern         TEXT NOT NULL,                     -- e.g. 'github.com/CHITTYOS/*', 'github.com/CHITTYFOUNDATION/*'
+  match_type      TEXT NOT NULL DEFAULT 'glob' CHECK(match_type IN ('glob', 'exact', 'prefix')),
+  allow_force     INTEGER NOT NULL DEFAULT 0,        -- 1 = force allowed (still requires confirm token + non-default-branch)
+  notes           TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, pattern)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_remote_allowlist_tenant
+  ON git_remote_allowlist(tenant_id);
+
+CREATE TABLE IF NOT EXISTS git_repo_allowlist (
+  tenant_id       TEXT NOT NULL,
+  path_prefix     TEXT NOT NULL,                     -- absolute path prefix; canonicalized at check time
+  access          TEXT NOT NULL DEFAULT 'read' CHECK(access IN ('read', 'write', 'readwrite')),
+  notes           TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, path_prefix)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_repo_allowlist_tenant
+  ON git_repo_allowlist(tenant_id);
+
+CREATE TABLE IF NOT EXISTS git_author_allowlist (
+  tenant_id       TEXT NOT NULL,
+  author_pattern  TEXT NOT NULL,                     -- e.g. 'Name <email@domain>' or glob 'ChittyOps <*@chitty.cc>'
+  match_type      TEXT NOT NULL DEFAULT 'glob' CHECK(match_type IN ('glob', 'exact')),
+  notes           TEXT,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, author_pattern)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_author_allowlist_tenant
+  ON git_author_allowlist(tenant_id);
+
+-- CF gateway membership tags — drives whether the chittyagent-git upstream is
+-- surfaced through a given aggregator for a given tenant. Read by the gateway
+-- registration helper at deploy time, NOT at request time.
+--
+-- Canonical tags (matches docs/upstreams/chittyagent-git.md in chittymcp):
+--   surface:all          → include in chittymcp
+--   audience:human       → include in ch1tty slim-MCP (search+execute)
+--   auth:oauth-ok        → include where OAuth is the auth model
+--   domain:messaging     → opt-in to chittymsg (chittyagent-git should NOT have this)
+CREATE TABLE IF NOT EXISTS git_gateway_tags (
+  tenant_id       TEXT NOT NULL,
+  tag             TEXT NOT NULL,                     -- 'surface:all', 'audience:human', 'auth:oauth-ok', etc.
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_gateway_tags_tenant
+  ON git_gateway_tags(tenant_id);
+
+-- Seed: ChittyOS default tenant gets the spec defaults from CHARTER.md.
+-- "Default allowlist: github.com/CHITTYOS/*, github.com/CHITTYFOUNDATION/*"
+INSERT OR IGNORE INTO git_remote_allowlist (tenant_id, pattern, match_type, allow_force, notes)
+VALUES
+  ('chittyos-default', 'github.com/CHITTYOS/*',         'glob', 0, 'CHARTER.md default'),
+  ('chittyos-default', 'github.com/CHITTYFOUNDATION/*', 'glob', 0, 'CHARTER.md default');
+
+INSERT OR IGNORE INTO git_repo_allowlist (tenant_id, path_prefix, access, notes)
+VALUES
+  ('chittyos-default', '/home/ubuntu/projects/github.com/CHITTYOS/',         'readwrite', 'VM canonical project root'),
+  ('chittyos-default', '/home/ubuntu/projects/github.com/CHITTYFOUNDATION/', 'readwrite', 'VM canonical project root');
+
+INSERT OR IGNORE INTO git_gateway_tags (tenant_id, tag)
+VALUES
+  ('chittyos-default', 'surface:all'),
+  ('chittyos-default', 'audience:human'),
+  ('chittyos-default', 'auth:oauth-ok');
+-- Explicitly NOT inserting 'domain:messaging' — chittyagent-git must not
+-- surface in chittymsg per the spec.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -38,6 +38,12 @@ wrangler d1 execute chittyconnect-production --env=production --file=migrations/
   - Tracks all credential provision operations
   - Supports revocation tracking
   - Indexes for common query patterns
+- **018_git_tenant_allowlists.sql** - Per-tenant policy for the Git Tool Surface
+  - `git_remote_allowlist` — which remote URL patterns a tenant may push to
+  - `git_repo_allowlist` — which absolute repo path prefixes are readable/writable
+  - `git_author_allowlist` — which commit identities a tenant may use
+  - `git_gateway_tags` — CF gateway membership tags for the `chittyagent-git` upstream
+  - Seeds `chittyos-default` tenant with the CHARTER.md default allowlists
 
 ## Creating New Migrations
 


### PR DESCRIPTION
## Summary
- D1 migration `018_git_tenant_allowlists.sql` adds four per-tenant policy tables: `git_remote_allowlist`, `git_repo_allowlist`, `git_author_allowlist`, `git_gateway_tags`
- Seeds `chittyos-default` tenant with the CHARTER.md default remote allowlist (`github.com/CHITTYOS/*`, `github.com/CHITTYFOUNDATION/*`) and the canonical VM repo roots
- CF gateway membership seeded with `surface:all` + `audience:human` + `auth:oauth-ok` so `chittyagent-git` surfaces in chittymcp + ch1tty; explicitly NOT tagged `domain:messaging` to keep it out of chittymsg
- Fail-closed: a tenant with no remote-allowlist rows cannot push

## Scope boundary
Schema + seeds only. The handlers that read these tables ship with #209 (deferred — needs 1Password signing-key provisioning before deploy).

## Test plan
- [x] SQL validated against in-memory SQLite (parses, seeds insert)
- [ ] Apply to staging: `wrangler d1 execute chittyconnect --env=staging --file=migrations/018_git_tenant_allowlists.sql`
- [ ] Apply to production: `wrangler d1 execute chittyconnect-production --env=production --file=migrations/018_git_tenant_allowlists.sql`
- [ ] Verify seeds: `wrangler d1 execute chittyconnect-production --env=production --command='SELECT * FROM git_remote_allowlist;'`

## Related
- Closes #211
- Parent spec: #208 (merged)
- Consumers: #209 (write handlers, deferred), #210 (#226, confirm endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)