### PR TITLE
feat(courtlistener): add /api/proxy/courtlistener proxy for ChittyCounsel

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1119,7 +1119,9 @@
         "summary": "Provision Tenant Database",
         "description": "Provision an isolated Neon database project for a tenant. Creates physical data isolation with base migrations for evidence storage and client data.",
         "operationId": "provisionTenant",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1127,11 +1129,22 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "tenantId": { "type": "string", "description": "Unique tenant identifier (ChittyID, org slug, or case ID)" },
-                  "region": { "type": "string", "description": "Neon region (default: aws-us-east-2)" },
-                  "pgVersion": { "type": "string", "description": "PostgreSQL version (default: 16)" }
+                  "tenantId": {
+                    "type": "string",
+                    "description": "Unique tenant identifier (ChittyID, org slug, or case ID)"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Neon region (default: aws-us-east-2)"
+                  },
+                  "pgVersion": {
+                    "type": "string",
+                    "description": "PostgreSQL version (default: 16)"
+                  }
                 },
-                "required": ["tenantId"]
+                "required": [
+                  "tenantId"
+                ]
               }
             }
           }
@@ -1144,18 +1157,33 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenantId": { "type": "string" },
-                    "neonProjectId": { "type": "string" },
-                    "region": { "type": "string" },
-                    "status": { "type": "string" },
-                    "migrationsApplied": { "type": "integer" },
-                    "createdAt": { "type": "string", "format": "date-time" }
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "neonProjectId": {
+                      "type": "string"
+                    },
+                    "region": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "migrationsApplied": {
+                      "type": "integer"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   }
                 }
               }
             }
           },
-          "409": { "description": "Tenant already provisioned" }
+          "409": {
+            "description": "Tenant already provisioned"
+          }
         }
       }
     },
@@ -1164,9 +1192,18 @@
         "summary": "Get Tenant Details",
         "description": "Retrieve details of a provisioned tenant's Neon project including project ID, region, and status.",
         "operationId": "getTenant",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "parameters": [
-          { "name": "tenantId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1176,28 +1213,55 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenantId": { "type": "string" },
-                    "neonProjectId": { "type": "string" },
-                    "region": { "type": "string" },
-                    "status": { "type": "string" },
-                    "pgVersion": { "type": "string" },
-                    "createdAt": { "type": "string", "format": "date-time" },
-                    "updatedAt": { "type": "string", "format": "date-time" }
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "neonProjectId": {
+                      "type": "string"
+                    },
+                    "region": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "pgVersion": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   }
                 }
               }
             }
           },
-          "404": { "description": "Tenant not found" }
+          "404": {
+            "description": "Tenant not found"
+          }
         }
       },
       "delete": {
         "summary": "Deprovision Tenant",
         "description": "Deprovision a tenant's Neon project. Deletes the project and marks the tenant as deprovisioned. This is destructive.",
         "operationId": "deprovisionTenant",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "parameters": [
-          { "name": "tenantId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1207,14 +1271,20 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenantId": { "type": "string" },
-                    "status": { "type": "string" }
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
                   }
                 }
               }
             }
           },
-          "404": { "description": "Tenant not found" }
+          "404": {
+            "description": "Tenant not found"
+          }
         }
       }
     },
@@ -1223,11 +1293,38 @@
         "summary": "List Tenant Projects",
         "description": "List all provisioned tenant Neon projects with pagination. Connection strings are never exposed.",
         "operationId": "listTenants",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "parameters": [
-          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["active", "suspended", "deprovisioned"] } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 50 } },
-          { "name": "offset", "in": "query", "schema": { "type": "integer", "default": 0 } }
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "suspended",
+                "deprovisioned"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1237,8 +1334,15 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenants": { "type": "array", "items": { "type": "object" } },
-                    "total": { "type": "integer" }
+                    "tenants": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -1252,9 +1356,18 @@
         "summary": "Export Tenant Project",
         "description": "Export tenant Neon project metadata for portability review. Does not expose connection credentials.",
         "operationId": "exportTenant",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "parameters": [
-          { "name": "tenantId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1264,17 +1377,30 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "tenantId": { "type": "string" },
-                    "neonProjectId": { "type": "string" },
-                    "region": { "type": "string" },
-                    "project": { "type": "object" },
-                    "exportedAt": { "type": "string", "format": "date-time" }
+                    "tenantId": {
+                      "type": "string"
+                    },
+                    "neonProjectId": {
+                      "type": "string"
+                    },
+                    "region": {
+                      "type": "string"
+                    },
+                    "project": {
+                      "type": "object"
+                    },
+                    "exportedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   }
                 }
               }
             }
           },
-          "404": { "description": "Tenant not found" }
+          "404": {
+            "description": "Tenant not found"
+          }
         }
       }
     },
@@ -1283,9 +1409,18 @@
         "summary": "Replicate Record to Tenant",
         "description": "Replicate a data record to a tenant's isolated Neon database. Supports evidence_documents, evidence_custody_log, document_families, client_documents, and financial_records tables. Column allowlists prevent SQL injection.",
         "operationId": "replicateToTenant",
-        "tags": ["Tenant Management"],
+        "tags": [
+          "Tenant Management"
+        ],
         "parameters": [
-          { "name": "tenantId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -1294,10 +1429,25 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "table": { "type": "string", "enum": ["evidence_documents", "evidence_custody_log", "document_families", "client_documents", "financial_records"] },
-                  "record": { "type": "object", "description": "Record data with column names as keys" }
+                  "table": {
+                    "type": "string",
+                    "enum": [
+                      "evidence_documents",
+                      "evidence_custody_log",
+                      "document_families",
+                      "client_documents",
+                      "financial_records"
+                    ]
+                  },
+                  "record": {
+                    "type": "object",
+                    "description": "Record data with column names as keys"
+                  }
                 },
-                "required": ["table", "record"]
+                "required": [
+                  "table",
+                  "record"
+                ]
               }
             }
           }
@@ -1310,10 +1460,18 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "replicated": { "type": "boolean" },
-                    "table": { "type": "string" },
-                    "recordId": { "type": "string" },
-                    "layer": { "type": "string" }
+                    "replicated": {
+                      "type": "boolean"
+                    },
+                    "table": {
+                      "type": "string"
+                    },
+                    "recordId": {
+                      "type": "string"
+                    },
+                    "layer": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -1324,63 +1482,258 @@
     },
     "/api/proxy/courtlistener/search": {
       "get": {
-        "tags": ["CourtListener"],
+        "tags": [
+          "CourtListener"
+        ],
         "summary": "CourtListener unified search (proxy)",
         "description": "Forwards to https://www.courtlistener.com/api/rest/v4/search/. 15-min Cache API wrap; bypass with header X-Bypass-Cache: 1. Fail-closed 503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE when token is not provisioned.",
         "parameters": [
-          { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Full-text query" },
-          { "name": "type", "in": "query", "schema": { "type": "string", "enum": ["o", "r", "rd", "d", "oa", "p"] }, "description": "Result type: o=opinions, r=RECAP, rd=RECAP documents, d=dockets, oa=oral args, p=people" },
-          { "name": "page_size", "in": "query", "schema": { "type": "integer" } },
-          { "name": "cursor", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Full-text query"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "o",
+                "r",
+                "rd",
+                "d",
+                "oa",
+                "p"
+              ]
+            },
+            "description": "Result type: o=opinions, r=RECAP, rd=RECAP documents, d=dockets, oa=oral args, p=people"
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Search results", "content": { "application/json": { "schema": { "type": "object" } } } },
-          "503": { "description": "CourtListener token not provisioned" }
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "CourtListener token not provisioned"
+          }
         }
       }
     },
     "/api/proxy/courtlistener/citation-lookup": {
       "post": {
-        "tags": ["CourtListener"],
+        "tags": [
+          "CourtListener"
+        ],
         "summary": "Citation lookup (proxy)",
         "description": "Forwards JSON body to https://www.courtlistener.com/api/rest/v4/citation-lookup/. Not cached.",
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "type": "object", "properties": { "text": { "type": "string" } }, "required": ["text"] } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Resolved citations", "content": { "application/json": { "schema": { "type": "array", "items": { "type": "object" } } } } },
-          "503": { "description": "CourtListener token not provisioned" }
+          "200": {
+            "description": "Resolved citations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "CourtListener token not provisioned"
+          }
         }
       }
     },
     "/api/proxy/courtlistener/{resource}": {
       "get": {
-        "tags": ["CourtListener"],
+        "tags": [
+          "CourtListener"
+        ],
         "summary": "Generic allowlisted resource fetch (proxy)",
-        "description": "Allowlist: opinions, clusters, dockets, docket-entries, recap-documents, audio, people, courts. Unknown resources → 404. 15-min Cache API wrap.",
+        "description": "Allowlist: opinions, clusters, dockets, docket-entries, recap-documents, audio, people, courts. Unknown resources are rejected with 400 path_not_allowed before any upstream call. 15-min Cache API wrap on the Worker side; Cache-Control header is not emitted to clients.",
         "parameters": [
-          { "name": "resource", "in": "path", "required": true, "schema": { "type": "string", "enum": ["opinions", "clusters", "dockets", "docket-entries", "recap-documents", "audio", "people", "courts"] } }
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "opinions",
+                "clusters",
+                "dockets",
+                "docket-entries",
+                "recap-documents",
+                "audio",
+                "people",
+                "courts"
+              ]
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Resource list", "content": { "application/json": { "schema": { "type": "object" } } } },
-          "404": { "description": "Unknown resource" },
-          "503": { "description": "CourtListener token not provisioned" }
+          "200": {
+            "description": "Resource list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "CourtListener token not provisioned"
+          },
+          "400": {
+            "description": "path_not_allowed \u2014 resource not in allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "path_not_allowed"
+                      ]
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "resource"
+                  ]
+                }
+              }
+            }
+          }
         }
       }
     },
     "/api/proxy/courtlistener/{resource}/{id}": {
       "get": {
-        "tags": ["CourtListener"],
+        "tags": [
+          "CourtListener"
+        ],
         "summary": "Allowlisted resource item fetch (proxy)",
         "parameters": [
-          { "name": "resource", "in": "path", "required": true, "schema": { "type": "string", "enum": ["opinions", "clusters", "dockets", "docket-entries", "recap-documents", "audio", "people", "courts"] } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "opinions",
+                "clusters",
+                "dockets",
+                "docket-entries",
+                "recap-documents",
+                "audio",
+                "people",
+                "courts"
+              ]
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Resource item", "content": { "application/json": { "schema": { "type": "object" } } } },
-          "404": { "description": "Unknown resource or item not found" },
-          "503": { "description": "CourtListener token not provisioned" }
+          "200": {
+            "description": "Resource item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "CourtListener token not provisioned"
+          },
+          "400": {
+            "description": "path_not_allowed \u2014 resource not in allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "path_not_allowed"
+                      ]
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "resource"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Item not found at upstream"
+          }
         }
       }
     }
@@ -1783,7 +2136,7 @@
     },
     {
       "name": "Tenant Management",
-      "description": "Project-per-tenant Neon database isolation — provision, query, export, and replicate data to physically isolated tenant databases for data ownership and portability"
+      "description": "Project-per-tenant Neon database isolation \u2014 provision, query, export, and replicate data to physically isolated tenant databases for data ownership and portability"
     }
   ]
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1321,6 +1321,68 @@
           }
         }
       }
+    },
+    "/api/proxy/courtlistener/search": {
+      "get": {
+        "tags": ["CourtListener"],
+        "summary": "CourtListener unified search (proxy)",
+        "description": "Forwards to https://www.courtlistener.com/api/rest/v4/search/. 15-min Cache API wrap; bypass with header X-Bypass-Cache: 1. Fail-closed 503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE when token is not provisioned.",
+        "parameters": [
+          { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Full-text query" },
+          { "name": "type", "in": "query", "schema": { "type": "string", "enum": ["o", "r", "rd", "d", "oa", "p"] }, "description": "Result type: o=opinions, r=RECAP, rd=RECAP documents, d=dockets, oa=oral args, p=people" },
+          { "name": "page_size", "in": "query", "schema": { "type": "integer" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Search results", "content": { "application/json": { "schema": { "type": "object" } } } },
+          "503": { "description": "CourtListener token not provisioned" }
+        }
+      }
+    },
+    "/api/proxy/courtlistener/citation-lookup": {
+      "post": {
+        "tags": ["CourtListener"],
+        "summary": "Citation lookup (proxy)",
+        "description": "Forwards JSON body to https://www.courtlistener.com/api/rest/v4/citation-lookup/. Not cached.",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "type": "object", "properties": { "text": { "type": "string" } }, "required": ["text"] } } }
+        },
+        "responses": {
+          "200": { "description": "Resolved citations", "content": { "application/json": { "schema": { "type": "array", "items": { "type": "object" } } } } },
+          "503": { "description": "CourtListener token not provisioned" }
+        }
+      }
+    },
+    "/api/proxy/courtlistener/{resource}": {
+      "get": {
+        "tags": ["CourtListener"],
+        "summary": "Generic allowlisted resource fetch (proxy)",
+        "description": "Allowlist: opinions, clusters, dockets, docket-entries, recap-documents, audio, people, courts. Unknown resources → 404. 15-min Cache API wrap.",
+        "parameters": [
+          { "name": "resource", "in": "path", "required": true, "schema": { "type": "string", "enum": ["opinions", "clusters", "dockets", "docket-entries", "recap-documents", "audio", "people", "courts"] } }
+        ],
+        "responses": {
+          "200": { "description": "Resource list", "content": { "application/json": { "schema": { "type": "object" } } } },
+          "404": { "description": "Unknown resource" },
+          "503": { "description": "CourtListener token not provisioned" }
+        }
+      }
+    },
+    "/api/proxy/courtlistener/{resource}/{id}": {
+      "get": {
+        "tags": ["CourtListener"],
+        "summary": "Allowlisted resource item fetch (proxy)",
+        "parameters": [
+          { "name": "resource", "in": "path", "required": true, "schema": { "type": "string", "enum": ["opinions", "clusters", "dockets", "docket-entries", "recap-documents", "audio", "people", "courts"] } },
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Resource item", "content": { "application/json": { "schema": { "type": "object" } } } },
+          "404": { "description": "Unknown resource or item not found" },
+          "503": { "description": "CourtListener token not provisioned" }
+        }
+      }
     }
   },
   "components": {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1538,6 +1538,9 @@
               }
             }
           },
+          "502": {
+            "description": "Bad Gateway — upstream fetch failed or returned invalid JSON"
+          },
           "503": {
             "description": "CourtListener token not provisioned"
           }
@@ -1583,6 +1586,9 @@
               }
             }
           },
+          "502": {
+            "description": "Bad Gateway — upstream fetch failed or returned invalid JSON"
+          },
           "503": {
             "description": "CourtListener token not provisioned"
           }
@@ -1626,6 +1632,9 @@
                 }
               }
             }
+          },
+          "502": {
+            "description": "Bad Gateway \u2014 upstream fetch failed or returned invalid JSON"
           },
           "503": {
             "description": "CourtListener token not provisioned"
@@ -1702,6 +1711,9 @@
                 }
               }
             }
+          },
+          "502": {
+            "description": "Bad Gateway \u2014 upstream fetch failed or returned invalid JSON"
           },
           "503": {
             "description": "CourtListener token not provisioned"

--- a/src/api/router.js
+++ b/src/api/router.js
@@ -22,6 +22,7 @@ import { registryRoutes } from "./routes/registry.js";
 import { servicesRoutes } from "./routes/services.js";
 import { thirdpartyRoutes } from "./routes/thirdparty.js";
 import { googleRoutes } from "./routes/google.js";
+import { courtlistenerRoutes } from "./routes/courtlistener.js";
 import { credentialsRoutes } from "./routes/credentials.js";
 import { intelligence } from "./routes/intelligence.js";
 import { mcpRoutes } from "./routes/mcp.js";
@@ -158,6 +159,7 @@ api.route("/api/services", servicesRoutes);
 api.route("/api/v1/services", servicesRoutes);
 api.route("/api/thirdparty", thirdpartyRoutes);
 api.route("/api/google", googleRoutes);
+api.route("/api/proxy/courtlistener", courtlistenerRoutes);
 
 // Mercury routes at /api/mercury/* — legacy path used by ChittyFinance.
 // Rewrites to /api/thirdparty/mercury/* so the thirdparty handler picks them up.

--- a/src/api/router.js
+++ b/src/api/router.js
@@ -71,6 +71,7 @@ api.use(
       "X-ChittyID",
       "Mcp-Session-Id",
       "Mcp-Protocol-Version",
+      "X-Bypass-Cache",
     ],
     exposeHeaders: ["Content-Length", "X-Request-ID", "Mcp-Session-Id"],
     maxAge: 86400,

--- a/src/api/routes/courtlistener.js
+++ b/src/api/routes/courtlistener.js
@@ -1,0 +1,276 @@
+/**
+ * CourtListener API Proxy Routes
+ *
+ * Proxies the Free Law Project's CourtListener REST API (v4) using a
+ * synthetic-env-injected API token. The token is delivered via the
+ * Cloudflare Secrets Store binding `COURTLISTENER_API_TOKEN` declared
+ * per environment in wrangler.jsonc.
+ *
+ * Token resolution priority:
+ *   1. env.COURTLISTENER_API_TOKEN (Cloudflare Secrets Store binding)
+ *   2. getCredential broker path (integrations/courtlistener/api_token)
+ *
+ * Allowlisted resources (REST v4):
+ *   - search, opinions, clusters, dockets, docket-entries,
+ *     recap-documents, audio, citation-lookup, people, courts
+ *
+ * Routes exposed:
+ *   - GET  /search
+ *   - GET  /:resource[/:id]
+ *   - POST /citation-lookup
+ *
+ * Edge behaviors:
+ *   - 15-minute Cache API wrap on GETs (bypass via `X-Bypass-Cache: 1`).
+ *   - Fail-closed 503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE when no
+ *     token is available from any source.
+ *   - Upstream error bodies truncated to 200 chars; the API token is
+ *     never echoed in errors or logs.
+ *
+ * Consumers: ChittyCounsel (counsel.chitty.cc).
+ *
+ * @canonical-uri chittycanon://core/services/chittyconnect#courtlistener-proxy
+ */
+
+import { Hono } from "hono";
+import { getCredential } from "../../lib/credential-helper.js";
+
+const courtlistenerRoutes = new Hono();
+// Auth: covered by /api/* authenticate middleware in router.js
+
+const CL_API = "https://www.courtlistener.com/api/rest/v4";
+const CACHE_TTL_SECONDS = 15 * 60; // 15 minutes
+
+// Allowlist of resources reachable through this proxy. Unknown resources
+// are rejected with 404 before any upstream call is made.
+const RESOURCE_ALLOWLIST = new Set([
+  "search",
+  "opinions",
+  "clusters",
+  "dockets",
+  "docket-entries",
+  "recap-documents",
+  "audio",
+  "citation-lookup",
+  "people",
+  "courts",
+]);
+
+/**
+ * Resolve the CourtListener API token from the synthetic env binding,
+ * falling back to the credential broker. Returns undefined if neither
+ * source has a value (the route then emits the fail-closed 503).
+ */
+async function getCourtListenerToken(env) {
+  if (env && env.COURTLISTENER_API_TOKEN) {
+    // Secrets Store bindings may surface as { get() } accessors; normalize.
+    const v = env.COURTLISTENER_API_TOKEN;
+    if (typeof v === "string") return v;
+    if (v && typeof v.get === "function") {
+      try {
+        const resolved = await v.get();
+        if (resolved) return resolved;
+      } catch {
+        // fall through to broker
+      }
+    }
+  }
+  return getCredential(
+    env,
+    "integrations/courtlistener/api_token",
+    "COURTLISTENER_API_TOKEN_FALLBACK",
+    "CourtListener",
+  );
+}
+
+/**
+ * Build a fail-closed 503 response when no token is available.
+ */
+function failClosedNoToken(c) {
+  return c.json(
+    {
+      error: "POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE",
+      detail: "CourtListener API token is not provisioned in this environment.",
+    },
+    503,
+  );
+}
+
+/**
+ * Perform a GET against CourtListener, optionally wrapped in the Cache API.
+ * The cache key is the absolute upstream URL; bypass via X-Bypass-Cache: 1.
+ */
+async function clGet(c, upstreamUrl) {
+  const bypass = c.req.header("X-Bypass-Cache") === "1";
+  const cache = !bypass && typeof caches !== "undefined" ? caches.default : null;
+  const cacheReq = new Request(upstreamUrl, { method: "GET" });
+
+  if (cache) {
+    try {
+      const hit = await cache.match(cacheReq);
+      if (hit) {
+        // Clone — Cache API responses are immutable
+        const cloned = new Response(hit.body, hit);
+        cloned.headers.set("X-Cache", "HIT");
+        return cloned;
+      }
+    } catch {
+      // cache.match failure is non-fatal; fall through to live fetch
+    }
+  }
+
+  const token = await getCourtListenerToken(c.env);
+  if (!token) return failClosedNoToken(c);
+
+  let upstream;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      headers: {
+        Authorization: `Token ${token}`,
+        Accept: "application/json",
+      },
+    });
+  } catch {
+    return c.json({ error: "CourtListener API request failed" }, 502);
+  }
+
+  if (!upstream.ok) {
+    const body = await upstream.text().catch(() => "");
+    return c.json(
+      { error: `CourtListener API ${upstream.status}: ${body.slice(0, 200)}` },
+      upstream.status,
+    );
+  }
+
+  let json;
+  try {
+    json = await upstream.json();
+  } catch {
+    return c.json({ error: "CourtListener API returned invalid JSON" }, 502);
+  }
+
+  const res = new Response(JSON.stringify(json), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}`,
+      "X-Cache": "MISS",
+    },
+  });
+
+  if (cache) {
+    try {
+      // Cache a clone so we can still return the original body
+      c.executionCtx && c.executionCtx.waitUntil
+        ? c.executionCtx.waitUntil(cache.put(cacheReq, res.clone()))
+        : await cache.put(cacheReq, res.clone());
+    } catch {
+      // cache.put failure is non-fatal
+    }
+  }
+
+  return res;
+}
+
+/**
+ * Build a CourtListener upstream URL for a given resource, optional id, and
+ * forwarded query string. Always appends a trailing slash before the query —
+ * CourtListener REST endpoints require it.
+ */
+function buildUpstream(resource, id, search) {
+  const path = id ? `${resource}/${encodeURIComponent(id)}` : `${resource}`;
+  const qs = search ? (search.startsWith("?") ? search : `?${search}`) : "";
+  return `${CL_API}/${path}/${qs}`;
+}
+
+// ============================================
+// GET /search
+// ============================================
+
+/**
+ * GET /search
+ * CourtListener unified search (opinions, RECAP, audio, judges).
+ * Forwards all query parameters verbatim to /api/rest/v4/search/.
+ */
+courtlistenerRoutes.get("/search", async (c) => {
+  const url = new URL(c.req.url);
+  return clGet(c, buildUpstream("search", null, url.search));
+});
+
+// ============================================
+// POST /citation-lookup
+// ============================================
+
+/**
+ * POST /citation-lookup
+ * Citation lookup endpoint — accepts a JSON body with citation text and
+ * returns parsed citations + resolved CourtListener clusters.
+ *
+ * Body is forwarded verbatim; not cached (POST).
+ */
+courtlistenerRoutes.post("/citation-lookup", async (c) => {
+  const token = await getCourtListenerToken(c.env);
+  if (!token) return failClosedNoToken(c);
+
+  const body = await c.req.text();
+  const contentType = c.req.header("Content-Type") || "application/json";
+
+  let upstream;
+  try {
+    upstream = await fetch(`${CL_API}/citation-lookup/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${token}`,
+        Accept: "application/json",
+        "Content-Type": contentType,
+      },
+      body,
+    });
+  } catch {
+    return c.json({ error: "CourtListener API request failed" }, 502);
+  }
+
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "");
+    return c.json(
+      { error: `CourtListener API ${upstream.status}: ${text.slice(0, 200)}` },
+      upstream.status,
+    );
+  }
+
+  let json;
+  try {
+    json = await upstream.json();
+  } catch {
+    return c.json({ error: "CourtListener API returned invalid JSON" }, 502);
+  }
+
+  return c.json(json);
+});
+
+// ============================================
+// GET /:resource[/:id]
+// ============================================
+
+/**
+ * GET /:resource and /:resource/:id
+ * Generic allowlisted resource fetch. Rejects unknown resources with 404
+ * before any upstream call. `id` is URL-encoded.
+ */
+courtlistenerRoutes.get("/:resource/:id?", async (c) => {
+  const resource = c.req.param("resource");
+  const id = c.req.param("id");
+
+  if (!RESOURCE_ALLOWLIST.has(resource)) {
+    return c.json({ error: `Unknown CourtListener resource: ${resource}` }, 404);
+  }
+
+  // citation-lookup is POST-only via this proxy
+  if (resource === "citation-lookup") {
+    return c.json({ error: "citation-lookup requires POST" }, 405);
+  }
+
+  const url = new URL(c.req.url);
+  return clGet(c, buildUpstream(resource, id, url.search));
+});
+
+export { courtlistenerRoutes };

--- a/src/api/routes/courtlistener.js
+++ b/src/api/routes/courtlistener.js
@@ -21,10 +21,15 @@
  *
  * Edge behaviors:
  *   - 15-minute Cache API wrap on GETs (bypass via `X-Bypass-Cache: 1`).
+ *     The cache key is the absolute upstream URL — intentionally NOT
+ *     tenant-scoped because CourtListener data is public Free Law Project
+ *     content and identical across tenants.
  *   - Fail-closed 503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE when no
  *     token is available from any source.
- *   - Upstream error bodies truncated to 200 chars; the API token is
- *     never echoed in errors or logs.
+ *   - Upstream error bodies are truncated to 200 chars AND scrubbed of
+ *     the resolved API token before being returned to clients.
+ *   - Unknown resources are rejected with 400 `path_not_allowed` (spec)
+ *     before any upstream call.
  *
  * Consumers: ChittyCounsel (counsel.chitty.cc).
  *
@@ -38,10 +43,9 @@ const courtlistenerRoutes = new Hono();
 // Auth: covered by /api/* authenticate middleware in router.js
 
 const CL_API = "https://www.courtlistener.com/api/rest/v4";
-const CACHE_TTL_SECONDS = 15 * 60; // 15 minutes
 
 // Allowlist of resources reachable through this proxy. Unknown resources
-// are rejected with 404 before any upstream call is made.
+// are rejected with 400 path_not_allowed before any upstream call is made.
 const RESOURCE_ALLOWLIST = new Set([
   "search",
   "opinions",
@@ -74,12 +78,28 @@ async function getCourtListenerToken(env) {
       }
     }
   }
+  // Broker path (1Password) with env-var fallback. Signature mirrors
+  // google.js: (env, brokerPath, fallbackEnvVar, logPrefix). The fallback
+  // env var name matches the Secrets Store binding above so a single
+  // configured value works whether delivered as a Secrets Store binding
+  // or a plain Worker env var.
   return getCredential(
     env,
     "integrations/courtlistener/api_token",
-    "COURTLISTENER_API_TOKEN_FALLBACK",
+    "COURTLISTENER_API_TOKEN",
     "CourtListener",
   );
+}
+
+/**
+ * Scrub the resolved API token from an upstream body before it is
+ * surfaced to the client. Defense-in-depth: if CourtListener ever
+ * reflects the Authorization header value back in an error response,
+ * this prevents it from leaking through the proxy.
+ */
+function scrubToken(text, token) {
+  if (!text || !token) return text || "";
+  return text.split(token).join("[REDACTED]");
 }
 
 /**
@@ -134,9 +154,10 @@ async function clGet(c, upstreamUrl) {
   }
 
   if (!upstream.ok) {
-    const body = await upstream.text().catch(() => "");
+    const raw = await upstream.text().catch(() => "");
+    const safe = scrubToken(raw, token).slice(0, 200);
     return c.json(
-      { error: `CourtListener API ${upstream.status}: ${body.slice(0, 200)}` },
+      { error: `CourtListener API ${upstream.status}: ${safe}` },
       upstream.status,
     );
   }
@@ -148,11 +169,15 @@ async function clGet(c, upstreamUrl) {
     return c.json({ error: "CourtListener API returned invalid JSON" }, 502);
   }
 
+  // Cache-Control is intentionally omitted on the client-facing response.
+  // The Worker Cache API stores responses internally and does not require
+  // a Cache-Control header for HIT semantics; emitting `public, max-age=…`
+  // would also instruct downstream browsers/CDNs to cache responses from
+  // an authenticated proxy, which is undesirable. Matches google.js.
   const res = new Response(JSON.stringify(json), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
-      "Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}`,
       "X-Cache": "MISS",
     },
   });
@@ -212,7 +237,6 @@ courtlistenerRoutes.post("/citation-lookup", async (c) => {
   if (!token) return failClosedNoToken(c);
 
   const body = await c.req.text();
-  const contentType = c.req.header("Content-Type") || "application/json";
 
   let upstream;
   try {
@@ -221,7 +245,11 @@ courtlistenerRoutes.post("/citation-lookup", async (c) => {
       headers: {
         Authorization: `Token ${token}`,
         Accept: "application/json",
-        "Content-Type": contentType,
+        // Pin Content-Type to application/json. CourtListener's
+        // citation-lookup endpoint only accepts JSON; forwarding an
+        // arbitrary client-supplied Content-Type would let a caller
+        // confuse the upstream parser.
+        "Content-Type": "application/json",
       },
       body,
     });
@@ -230,9 +258,10 @@ courtlistenerRoutes.post("/citation-lookup", async (c) => {
   }
 
   if (!upstream.ok) {
-    const text = await upstream.text().catch(() => "");
+    const raw = await upstream.text().catch(() => "");
+    const safe = scrubToken(raw, token).slice(0, 200);
     return c.json(
-      { error: `CourtListener API ${upstream.status}: ${text.slice(0, 200)}` },
+      { error: `CourtListener API ${upstream.status}: ${safe}` },
       upstream.status,
     );
   }
@@ -253,15 +282,17 @@ courtlistenerRoutes.post("/citation-lookup", async (c) => {
 
 /**
  * GET /:resource and /:resource/:id
- * Generic allowlisted resource fetch. Rejects unknown resources with 404
- * before any upstream call. `id` is URL-encoded.
+ * Generic allowlisted resource fetch. Rejects unknown resources with
+ * 400 path_not_allowed before any upstream call. `id` is URL-encoded.
  */
 courtlistenerRoutes.get("/:resource/:id?", async (c) => {
   const resource = c.req.param("resource");
   const id = c.req.param("id");
 
   if (!RESOURCE_ALLOWLIST.has(resource)) {
-    return c.json({ error: `Unknown CourtListener resource: ${resource}` }, 404);
+    // Spec error code: 400 path_not_allowed. Includes the offending
+    // resource string for operator-side diagnostics.
+    return c.json({ error: "path_not_allowed", resource }, 400);
   }
 
   // citation-lookup is POST-only via this proxy

--- a/src/api/routes/courtlistener.js
+++ b/src/api/routes/courtlistener.js
@@ -78,15 +78,15 @@ async function getCourtListenerToken(env) {
       }
     }
   }
-  // Broker path (1Password) with env-var fallback. Signature mirrors
-  // google.js: (env, brokerPath, fallbackEnvVar, logPrefix). The fallback
-  // env var name matches the Secrets Store binding above so a single
-  // configured value works whether delivered as a Secrets Store binding
-  // or a plain Worker env var.
+  // Broker path (1Password). No env-var fallback: the Secrets Store binding
+  // is already resolved above, so resolution is exactly two explicit sources
+  // (Secrets Store binding, then broker). Passing an env-var fallback here
+  // would silently reopen a third, undeclared credential path outside the
+  // Secrets Store / broker-only policy for this proxy.
   return getCredential(
     env,
     "integrations/courtlistener/api_token",
-    "COURTLISTENER_API_TOKEN",
+    undefined,
     "CourtListener",
   );
 }
@@ -121,6 +121,14 @@ function failClosedNoToken(c) {
  */
 async function clGet(c, upstreamUrl) {
   const bypass = c.req.header("X-Bypass-Cache") === "1";
+
+  // Resolve the token BEFORE consulting the cache. A cache HIT must not be
+  // allowed to bypass the fail-closed contract: if the token is removed or
+  // its source becomes unavailable, every request — cached or not — must
+  // emit the 503, not keep serving stale cached upstream data.
+  const token = await getCourtListenerToken(c.env);
+  if (!token) return failClosedNoToken(c);
+
   const cache = !bypass && typeof caches !== "undefined" ? caches.default : null;
   const cacheReq = new Request(upstreamUrl, { method: "GET" });
 
@@ -137,9 +145,6 @@ async function clGet(c, upstreamUrl) {
       // cache.match failure is non-fatal; fall through to live fetch
     }
   }
-
-  const token = await getCourtListenerToken(c.env);
-  if (!token) return failClosedNoToken(c);
 
   let upstream;
   try {

--- a/tests/api/courtlistener-routes.test.js
+++ b/tests/api/courtlistener-routes.test.js
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ----------------------------------------------------------------
+// Mocks — mirror the established pattern in google-routes.test.js
+// (route unit test of identical shape; service-integration smoke
+// is performed post-deploy via real curl per the deploy runbook).
+// ----------------------------------------------------------------
+
+vi.mock("../../src/middleware/require-service-token.js", () => ({
+  requireServiceToken: () => async (_c, next) => { await next(); },
+}));
+
+const mockGetCredential = vi.fn().mockResolvedValue(undefined);
+vi.mock("../../src/lib/credential-helper.js", () => ({
+  getCredential: (...args) => mockGetCredential(...args),
+}));
+
+const { courtlistenerRoutes } = await import(
+  "../../src/api/routes/courtlistener.js"
+);
+
+function makeEnv(overrides = {}) {
+  return {
+    COURTLISTENER_API_TOKEN: "test-cl-token",
+    ...overrides,
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(status, text = "Error") {
+  return new Response(text, { status });
+}
+
+async function req(method, path, env, { query = "", body, headers = {} } = {}) {
+  const url = `http://localhost${path}${query ? `?${query}` : ""}`;
+  const init = { method, headers };
+  if (body !== undefined) {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+    init.headers["Content-Type"] = init.headers["Content-Type"] || "application/json";
+  }
+  // Pass an empty caches stub by default — Cache API isn't present in vitest
+  return courtlistenerRoutes.fetch(new Request(url, init), env);
+}
+
+const get = (path, env, opts) => req("GET", path, env, opts);
+const post = (path, env, opts) => req("POST", path, env, opts);
+
+// ----------------------------------------------------------------
+// Token resolution + fail-closed
+// ----------------------------------------------------------------
+
+describe("CourtListener token resolution", () => {
+  let originalFetch;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses env.COURTLISTENER_API_TOKEN when present (Token scheme, not Bearer)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+    await get("/search", makeEnv(), { query: "q=foo" });
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Token test-cl-token");
+  });
+
+  it("falls back to getCredential when env binding is missing", async () => {
+    mockGetCredential.mockResolvedValueOnce("broker-cl-token");
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+    await get("/search", makeEnv({ COURTLISTENER_API_TOKEN: undefined }), { query: "q=foo" });
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Token broker-cl-token");
+  });
+
+  it("supports Secrets Store accessor-style bindings ({ get() })", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+    const env = makeEnv({
+      COURTLISTENER_API_TOKEN: { get: vi.fn().mockResolvedValue("secrets-store-token") },
+    });
+    await get("/search", env, { query: "q=foo" });
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Token secrets-store-token");
+  });
+
+  it("fails closed with 503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE when no token available", async () => {
+    mockGetCredential.mockResolvedValueOnce(undefined);
+    const res = await get("/search", makeEnv({ COURTLISTENER_API_TOKEN: undefined }), {
+      query: "q=foo",
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE");
+  });
+
+  it("503 path also applies to POST /citation-lookup when no token available", async () => {
+    mockGetCredential.mockResolvedValueOnce(undefined);
+    const res = await post("/citation-lookup", makeEnv({ COURTLISTENER_API_TOKEN: undefined }), {
+      body: { text: "410 U.S. 113" },
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE");
+  });
+});
+
+// ----------------------------------------------------------------
+// GET /search
+// ----------------------------------------------------------------
+
+describe("GET /search", () => {
+  let env;
+  let originalFetch;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("forwards query parameters verbatim to /api/rest/v4/search/", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+    await get("/search", env, { query: "type=o&q=miranda&page_size=3" });
+    const [url] = globalThis.fetch.mock.calls[0];
+    expect(url).toContain("https://www.courtlistener.com/api/rest/v4/search/");
+    expect(url).toContain("type=o");
+    expect(url).toContain("q=miranda");
+    expect(url).toContain("page_size=3");
+  });
+
+  it("returns 200 + parsed JSON on upstream success", async () => {
+    const payload = { count: 1, results: [{ caseName: "Miranda v. Arizona" }] };
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(payload));
+    const res = await get("/search", env, { query: "q=miranda" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0].caseName).toBe("Miranda v. Arizona");
+  });
+
+  it("propagates upstream non-2xx status and truncates body to 200 chars", async () => {
+    const longBody = "x".repeat(500);
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(403, longBody));
+    const res = await get("/search", env, { query: "q=foo" });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("403");
+    expect(body.error.length).toBeLessThan(400);
+  });
+
+  it("returns 502 on network error", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("network"));
+    const res = await get("/search", env, { query: "q=foo" });
+    expect(res.status).toBe(502);
+  });
+
+  it("never echoes the API token in error bodies", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(500, "boom test-cl-token boom"));
+    const res = await get("/search", env, { query: "q=foo" });
+    const body = await res.json();
+    // Truncation may still surface the token from upstream — but the proxy itself
+    // does not add it. Assert no extra header echo and the token isn't in error key path.
+    expect(body.error).not.toContain("Authorization");
+  });
+});
+
+// ----------------------------------------------------------------
+// Allowlist enforcement on /:resource
+// ----------------------------------------------------------------
+
+describe("GET /:resource allowlist", () => {
+  let env;
+  let originalFetch;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+  });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("404s unknown resource without calling upstream", async () => {
+    const res = await get("/not-a-real-resource", env);
+    expect(res.status).toBe(404);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("allows opinions/:id (URL-encoded)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ id: 12345 }));
+    const res = await get("/opinions/12345", env);
+    expect(res.status).toBe(200);
+    const [url] = globalThis.fetch.mock.calls[0];
+    expect(url).toBe("https://www.courtlistener.com/api/rest/v4/opinions/12345/");
+  });
+
+  it("allows dockets list with query", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+    await get("/dockets", env, { query: "court=scotus" });
+    const [url] = globalThis.fetch.mock.calls[0];
+    expect(url).toContain("/dockets/");
+    expect(url).toContain("court=scotus");
+  });
+
+  it("405s GET /citation-lookup (POST-only)", async () => {
+    const res = await get("/citation-lookup", env);
+    expect(res.status).toBe(405);
+  });
+
+  it("URL-encodes id parameter to prevent path injection", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({}));
+    await get("/clusters/abc%2Fdef", env);
+    const [url] = globalThis.fetch.mock.calls[0];
+    // Hono decodes %2F to / in the route param; the proxy then re-encodes
+    // it so the slash never reaches the upstream path as a separator.
+    expect(url).toContain("/clusters/abc%2Fdef/");
+    expect(url).not.toMatch(/\/clusters\/abc\/def\//);
+  });
+
+  it("allows all spec-required resources", async () => {
+    const allowed = [
+      "search",
+      "opinions",
+      "clusters",
+      "dockets",
+      "docket-entries",
+      "recap-documents",
+      "audio",
+      "people",
+      "courts",
+    ];
+    for (const resource of allowed) {
+      globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+      const res = await get(`/${resource}`, env);
+      expect(res.status, `expected 200 for ${resource}`).toBe(200);
+    }
+  });
+});
+
+// ----------------------------------------------------------------
+// POST /citation-lookup
+// ----------------------------------------------------------------
+
+describe("POST /citation-lookup", () => {
+  let env;
+  let originalFetch;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it("forwards POST body verbatim with Token auth", async () => {
+    const upstreamResponse = [{ citation: "410 U.S. 113", normalized_citations: ["410 U.S. 113"] }];
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(upstreamResponse));
+
+    const res = await post("/citation-lookup", env, { body: { text: "Roe v. Wade, 410 U.S. 113" } });
+    expect(res.status).toBe(200);
+    const [url, init] = globalThis.fetch.mock.calls[0];
+    expect(url).toBe("https://www.courtlistener.com/api/rest/v4/citation-lookup/");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe("Token test-cl-token");
+    expect(JSON.parse(init.body).text).toBe("Roe v. Wade, 410 U.S. 113");
+  });
+
+  it("returns upstream error with truncation", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(400, "y".repeat(500)));
+    const res = await post("/citation-lookup", env, { body: { text: "garbage" } });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.length).toBeLessThan(400);
+  });
+});
+
+// ----------------------------------------------------------------
+// Cache behavior
+// ----------------------------------------------------------------
+
+describe("Cache API wrap on GETs", () => {
+  let env;
+  let originalFetch;
+  let originalCaches;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+    originalFetch = globalThis.fetch;
+    originalCaches = globalThis.caches;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.caches = originalCaches;
+  });
+
+  it("returns cached response on cache hit without calling upstream", async () => {
+    const cached = jsonResponse({ count: 99, results: ["from-cache"] });
+    globalThis.caches = {
+      default: {
+        match: vi.fn().mockResolvedValue(cached),
+        put: vi.fn(),
+      },
+    };
+    globalThis.fetch = vi.fn();
+
+    const res = await get("/search", env, { query: "q=cached" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("bypasses cache when X-Bypass-Cache: 1 header is set", async () => {
+    globalThis.caches = {
+      default: {
+        match: vi.fn().mockResolvedValue(jsonResponse({ count: 1, results: ["from-cache"] })),
+        put: vi.fn(),
+      },
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+
+    const res = await get("/search", env, {
+      query: "q=fresh",
+      headers: { "X-Bypass-Cache": "1" },
+    });
+    expect(res.status).toBe(200);
+    expect(globalThis.caches.default.match).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("sets X-Cache: MISS + Cache-Control on cache miss", async () => {
+    globalThis.caches = {
+      default: {
+        match: vi.fn().mockResolvedValue(undefined),
+        put: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ count: 0, results: [] }));
+
+    const res = await get("/search", env, { query: "q=miss" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=900");
+  });
+});

--- a/tests/api/courtlistener-routes.test.js
+++ b/tests/api/courtlistener-routes.test.js
@@ -150,8 +150,8 @@ describe("GET /search", () => {
     const res = await get("/search", env, { query: "q=foo" });
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toContain("403");
-    expect(body.error.length).toBeLessThan(400);
+    // Assert the exact 200-char truncation contract, not a loose bound.
+    expect(body.error).toBe(`CourtListener API 403: ${"x".repeat(200)}`);
   });
 
   it("returns 502 on network error", async () => {
@@ -301,7 +301,8 @@ describe("POST /citation-lookup", () => {
     const res = await post("/citation-lookup", env, { body: { text: "garbage" } });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error.length).toBeLessThan(400);
+    // Assert the exact 200-char truncation contract, not a loose bound.
+    expect(body.error).toBe(`CourtListener API 400: ${"y".repeat(200)}`);
   });
 
   it("scrubs the API token from POST error bodies", async () => {
@@ -368,6 +369,25 @@ describe("Cache API wrap on GETs", () => {
     const res = await get("/search", env, { query: "q=cached" });
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (503) even on a cache hit when no token is available", async () => {
+    // Regression: a cache HIT must not bypass the fail-closed token contract.
+    const cacheMatch = vi.fn().mockResolvedValue(jsonResponse({ count: 99, results: ["stale"] }));
+    globalThis.caches = { default: { match: cacheMatch, put: vi.fn() } };
+    globalThis.fetch = vi.fn();
+    mockGetCredential.mockResolvedValueOnce(undefined);
+
+    const res = await get("/search", makeEnv({ COURTLISTENER_API_TOKEN: undefined }), {
+      query: "q=cached",
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE");
+    // Token resolution gates the cache: a HIT must not be served, and no
+    // upstream fetch should occur either.
+    expect(cacheMatch).not.toHaveBeenCalled();
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 

--- a/tests/api/courtlistener-routes.test.js
+++ b/tests/api/courtlistener-routes.test.js
@@ -160,13 +160,28 @@ describe("GET /search", () => {
     expect(res.status).toBe(502);
   });
 
-  it("never echoes the API token in error bodies", async () => {
+  it("scrubs the resolved API token from error body (defense-in-depth)", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(500, "boom test-cl-token boom"));
     const res = await get("/search", env, { query: "q=foo" });
     const body = await res.json();
-    // Truncation may still surface the token from upstream — but the proxy itself
-    // does not add it. Assert no extra header echo and the token isn't in error key path.
+    expect(body.error).not.toContain("test-cl-token");
+    expect(body.error).toContain("[REDACTED]");
     expect(body.error).not.toContain("Authorization");
+  });
+
+  it("does not leak the token in success-path response bodies", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      jsonResponse({ count: 0, results: [], note: "harmless" })
+    );
+    const res = await get("/search", env, { query: "q=ok" });
+    const text = await res.text();
+    expect(text).not.toContain("test-cl-token");
+  });
+
+  it("propagates upstream 429 rate-limit status to the client", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(429, "Too Many Requests"));
+    const res = await get("/search", env, { query: "q=foo" });
+    expect(res.status).toBe(429);
   });
 });
 
@@ -185,9 +200,21 @@ describe("GET /:resource allowlist", () => {
   });
   afterEach(() => { globalThis.fetch = originalFetch; });
 
-  it("404s unknown resource without calling upstream", async () => {
+  it("400 path_not_allowed for unknown resource without calling upstream", async () => {
     const res = await get("/not-a-real-resource", env);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("path_not_allowed");
+    expect(body.resource).toBe("not-a-real-resource");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("400 path_not_allowed includes the offending resource string", async () => {
+    const res = await get("/etc-passwd-style-injection", env);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("path_not_allowed");
+    expect(typeof body.resource).toBe("string");
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -276,6 +303,36 @@ describe("POST /citation-lookup", () => {
     const body = await res.json();
     expect(body.error.length).toBeLessThan(400);
   });
+
+  it("scrubs the API token from POST error bodies", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      errorResponse(500, "internal failure test-cl-token internal")
+    );
+    const res = await post("/citation-lookup", env, { body: { text: "x" } });
+    const body = await res.json();
+    expect(body.error).not.toContain("test-cl-token");
+    expect(body.error).toContain("[REDACTED]");
+  });
+
+  it("pins upstream Content-Type to application/json regardless of client header", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse([]));
+    await post("/citation-lookup", env, {
+      body: '{"text":"x"}',
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+    const [, init] = globalThis.fetch.mock.calls[0];
+    expect(init.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("never consults Cache API for POST (POST is not cached)", async () => {
+    const cacheMatch = vi.fn().mockResolvedValue(undefined);
+    const cachePut = vi.fn().mockResolvedValue(undefined);
+    globalThis.caches = { default: { match: cacheMatch, put: cachePut } };
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse([]));
+    await post("/citation-lookup", env, { body: { text: "x" } });
+    expect(cacheMatch).not.toHaveBeenCalled();
+    expect(cachePut).not.toHaveBeenCalled();
+  });
 });
 
 // ----------------------------------------------------------------
@@ -344,6 +401,9 @@ describe("Cache API wrap on GETs", () => {
     const res = await get("/search", env, { query: "q=miss" });
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Cache")).toBe("MISS");
-    expect(res.headers.get("Cache-Control")).toContain("max-age=900");
+    // Cache-Control is intentionally NOT emitted on proxy responses
+    // (Worker Cache API stores internally; downstream CDNs/browsers
+    // must not cache authenticated-proxy responses).
+    expect(res.headers.get("Cache-Control")).toBeNull();
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -78,7 +78,7 @@
     { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
     { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
     { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
+        { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
 
   // ──────────────────────────────────────────────────────────────────
@@ -205,7 +205,7 @@
         { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
+        { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
       "vars": {
         "ENVIRONMENT": "staging",
@@ -334,7 +334,7 @@
         { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
+        { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
 
       "routes": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -77,7 +77,8 @@
     { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
     { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
     { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-    { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
+    { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
 
   // ──────────────────────────────────────────────────────────────────
@@ -203,7 +204,8 @@
         { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
       "vars": {
         "ENVIRONMENT": "staging",
@@ -331,7 +333,8 @@
         { "binding": "MERCURY_OIDC_ISSUER", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "MERCURY_OIDC_ISSUER" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
         { "binding": "CHITTYAUTH_ISSUED_MINT_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
-        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" }
+        { "binding": "MINT_API_KEY", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "chittyauth_issued_mint_api_key" },
+    { "binding": "COURTLISTENER_API_TOKEN", "store_id": "e914522471964c3c8cf1e601770edcc3", "secret_name": "COURTLISTENER_API_TOKEN" }
       ],
 
       "routes": [


### PR DESCRIPTION
## Summary

Adds a CourtListener REST v4 proxy at `/api/proxy/courtlistener/*` for ChittyCounsel (PR https://github.com/chittycorp/CHITTYCOUNSEL/pull/4). Mirrors the established `google.js` proxy pattern with CourtListener-specific behaviors per spec.

## Endpoints

- `GET  /api/proxy/courtlistener/search` — unified search, query passthrough
- `GET  /api/proxy/courtlistener/:resource[/:id]` — allowlisted resource fetch
- `POST /api/proxy/courtlistener/citation-lookup` — citation lookup, body forwarded verbatim

**Allowlist:** `search, opinions, clusters, dockets, docket-entries, recap-documents, audio, citation-lookup, people, courts`. Unknown resources → 404 before any upstream call.

## Spec compliance vs google.js (deltas)

- `Authorization: Token <key>` (CL convention, not Bearer)
- Fail-closed `503 POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE` when token absent
- 15-min Cache API wrap on GETs; `X-Bypass-Cache: 1` escape
- POST `/citation-lookup` body forwarding
- Resource allowlist enforced server-side

## Credential plane (synthetic env model)

Token is delivered via Cloudflare Secrets Store binding `COURTLISTENER_API_TOKEN` declared in `wrangler.jsonc` at:
- top-level (inherited by `dev`)
- `env.staging.secrets_store_secrets`
- `env.production.secrets_store_secrets`

All three reference store `e914522471964c3c8cf1e601770edcc3`.

**Status of the secret VALUE:** NOT yet present in the store — verified via `npx wrangler secrets-store secret list e914522471964c3c8cf1e601770edcc3 --remote --per-page 100` (no entry matching `court`). This is a known provisioning gap that **chico** owns downstream. Until the value is written, the 503 fail-closed path is exercised — deploy of this PR is safe and non-disruptive (no behavior change to existing routes; new routes simply return 503 to consumers).

No operator credential paste path. No `op://` URI dependency.

## Tests

21 new unit tests in `tests/api/courtlistener-routes.test.js`, mirroring the established `google-routes.test.js` pattern (`vi.mock` on `credential-helper` — repo-local convention for route unit tests; real service-integration smoke is the post-deploy `curl` evidence in the test plan below).

```
Test Files  12 passed (12)
Tests      137 passed (137)
```

## Files

- `src/api/routes/courtlistener.js` (new) — proxy implementation
- `src/api/router.js` — mounts at `/api/proxy/courtlistener`
- `wrangler.jsonc` — 3 `secrets_store_secrets` binding entries (top + staging + production)
- `public/openapi.json` — 4 path entries under `CourtListener` tag
- `tests/api/courtlistener-routes.test.js` (new) — 21 tests

## Test plan

- [x] `npx vitest run tests/api/courtlistener-routes.test.js` — 21/21 pass
- [x] `npx vitest run tests/api/` — 137/137 pass (no regressions)
- [x] `npx eslint src/api/routes/courtlistener.js tests/api/courtlistener-routes.test.js` — clean
- [x] `wrangler.jsonc` parses (JSONC strip-comments + JSON.parse)
- [x] `public/openapi.json` parses
- [ ] **Operator approval** before `npm run deploy:staging` / `npm run deploy:production` (safe-deploy)
- [ ] **chico** provisions `COURTLISTENER_API_TOKEN` value into Cloudflare Secrets Store `e914522471964c3c8cf1e601770edcc3`
- [ ] Post-deploy real curl evidence (per the spec):
  ```bash
  curl -sS -H "Authorization: Bearer $CHITTY_CONNECT_TEST_TOKEN" \
    "https://connect.chitty.cc/api/proxy/courtlistener/search?type=o&q=miranda&page_size=3" \
    | jq '{ok, count: (.data.count // 0), first: .data.results[0].caseName}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added CourtListener proxy API endpoints for search queries, citation lookup, and allowlisted resource access with integrated caching support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->