### PR TITLE
docs(git-mcp): reframe as broker primitives — corrects #208

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -146,9 +146,12 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 #### `[SPEC] POST /api/v1/capabilities/mint`
 
 Mint a short-TTL capability token scoped to a single caller × tenant × repo ×
-operation. Tokens are opaque to clients; their claims are obtained via
-`introspect`. For `operation = "write"` with `force_class != "none"`, a fresh
-confirmation token from `/api/v1/capabilities/confirm` is required.
+operation × ref. Tokens are opaque to clients; their claims are obtained via
+`introspect`. Capabilities are bound to a granular `operation`
+(`read | commit | tag | push`) and MAY NOT be reused for a different action —
+a `commit` capability cannot sign a tag or emit a push event. For
+`operation = "push"` with `force_class != "none"`, a fresh confirmation token
+from `/api/v1/capabilities/confirm` is required.
 
 ```json
 {
@@ -158,15 +161,30 @@ confirmation token from `/api/v1/capabilities/confirm` is required.
     "required": ["caller_chittyid", "tenant_id", "operation", "repo_path"],
     "additionalProperties": false,
     "properties": {
-      "caller_chittyid":    { "type": "string", "pattern": "^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-[PLTEA]-[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]$" },
+      "caller_chittyid":    { "type": "string", "pattern": "^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-[PLTEA]-[0-9]{4}-[0-5]-[0-9]{2}$", "description": "Canonical ChittyID VV-G-LLL-SSSS-T-YYMM-C-XX per chittycanon://gov/governance. T in {P,L,T,E,A}; YYMM is year-month; C is trust level 0-5; XX is mod-97 checksum." },
       "tenant_id":          { "type": "string", "minLength": 1, "maxLength": 128 },
-      "operation":          { "type": "string", "enum": ["read", "write"] },
+      "operation":          { "type": "string", "enum": ["read", "commit", "tag", "push"] },
       "repo_path":          { "type": "string", "minLength": 1, "description": "Absolute path; validated against tenant repo allowlist." },
-      "remote":             { "type": "string", "description": "Required when operation=write and the downstream call is a push." },
+      "remote":             { "type": "string", "description": "Required when operation='push'." },
+      "ref":                { "type": "string", "description": "Required when operation ∈ {commit, tag, push}. Concrete ref (e.g. refs/heads/main, refs/tags/v1.2.3) the capability binds to." },
       "force_class":        { "type": "string", "enum": ["none", "force", "force_with_lease"], "default": "none" },
-      "confirmation_token": { "type": "string", "description": "Required when force_class != 'none'." }
+      "confirmation_token": { "type": "string", "description": "Required when operation='push' AND force_class != 'none'." }
     },
     "allOf": [
+      {
+        "if": {
+          "properties": { "operation": { "enum": ["commit", "tag", "push"] } },
+          "required": ["operation"]
+        },
+        "then": { "required": ["ref"] }
+      },
+      {
+        "if": {
+          "properties": { "operation": { "const": "push" } },
+          "required": ["operation"]
+        },
+        "then": { "required": ["remote"] }
+      },
       {
         "if": {
           "properties": { "force_class": { "enum": ["force", "force_with_lease"] } },
@@ -191,9 +209,10 @@ confirmation token from `/api/v1/capabilities/confirm` is required.
         "properties": {
           "caller_chittyid": { "type": "string" },
           "tenant_id":       { "type": "string" },
-          "operation":       { "type": "string", "enum": ["read", "write"] },
+          "operation":       { "type": "string", "enum": ["read", "commit", "tag", "push"] },
           "repo_path":       { "type": "string" },
           "remote":          { "type": "string" },
+          "ref":             { "type": "string" },
           "force_class":     { "type": "string", "enum": ["none", "force", "force_with_lease"] }
         }
       }
@@ -226,17 +245,21 @@ git operation. Fail-closed if unreachable.
       "expires_at": { "type": "string", "format": "date-time" },
       "scope": {
         "type": "object",
+        "required": ["caller_chittyid", "tenant_id", "operation", "repo_path", "remote", "force_class"],
         "additionalProperties": false,
         "properties": {
           "caller_chittyid": { "type": "string" },
           "tenant_id":       { "type": "string" },
-          "operation":       { "type": "string", "enum": ["read", "write"] },
+          "operation":       { "type": "string", "enum": ["read", "commit", "tag", "push"] },
           "repo_path":       { "type": "string" },
           "remote":          { "type": "string" },
+          "ref":             { "type": "string" },
           "force_class":     { "type": "string", "enum": ["none", "force", "force_with_lease"] }
         }
       }
-    }
+    },
+    "if":   { "properties": { "active": { "const": true } }, "required": ["active"] },
+    "then": { "required": ["scope"] }
   }
 }
 ```
@@ -245,29 +268,49 @@ git operation. Fail-closed if unreachable.
 
 Issue a short-TTL confirmation token. Required as a second factor before
 minting a capability with `force_class != "none"`. Confirmation tokens are
-single-use and bound to caller+tenant+repo+force_class.
+single-use and bound to caller+tenant+repo+remote+ref+force_class. A
+confirmation issued for one (`remote`, `ref`) pair (e.g. `origin` +
+`refs/heads/feature`) CANNOT be redeemed to force-push a different ref
+(e.g. `refs/heads/main`) — the resource server MUST reject scope-mismatched
+tokens with `POLICY_BLOCKED_CONFIRMATION_INVALID`.
 
 ```json
 {
   "name": "capabilities.confirm",
   "input_schema": {
     "type": "object",
-    "required": ["caller_chittyid", "tenant_id", "repo_path", "force_class"],
+    "required": ["caller_chittyid", "tenant_id", "repo_path", "remote", "ref", "force_class"],
     "additionalProperties": false,
     "properties": {
       "caller_chittyid": { "type": "string" },
       "tenant_id":       { "type": "string" },
       "repo_path":       { "type": "string" },
+      "remote":          { "type": "string", "description": "Remote the confirmation authorizes (e.g. 'origin')." },
+      "ref":             { "type": "string", "description": "Concrete ref the confirmation authorizes (e.g. refs/heads/feature). NOT interchangeable across refs." },
       "force_class":     { "type": "string", "enum": ["force", "force_with_lease"] }
     }
   },
   "output_schema": {
     "type": "object",
-    "required": ["confirmation_token", "expires_at"],
+    "required": ["confirmation_token", "expires_at", "bound_scope"],
     "additionalProperties": false,
     "properties": {
       "confirmation_token": { "type": "string" },
-      "expires_at":         { "type": "string", "format": "date-time", "description": "TTL <= 120s." }
+      "expires_at":         { "type": "string", "format": "date-time", "description": "TTL <= 120s." },
+      "bound_scope": {
+        "type": "object",
+        "required": ["caller_chittyid", "tenant_id", "repo_path", "remote", "ref", "force_class"],
+        "additionalProperties": false,
+        "properties": {
+          "caller_chittyid": { "type": "string" },
+          "tenant_id":       { "type": "string" },
+          "repo_path":       { "type": "string" },
+          "remote":          { "type": "string" },
+          "ref":             { "type": "string" },
+          "force_class":     { "type": "string", "enum": ["force", "force_with_lease"] }
+        },
+        "description": "Echo of the exact (caller, tenant, repo, remote, ref, force_class) tuple this token binds to. Mint MUST reject if any field differs."
+      }
     }
   }
 }
@@ -278,7 +321,7 @@ single-use and bound to caller+tenant+repo+force_class.
 Produce a detached signature over the canonical commit payload supplied by the
 resource server. The signing key (resolved from 1Password by the broker) never
 leaves ChittyConnect. The resource server MUST present a valid capability
-token whose scope satisfies `operation=write` and matches `repo_path`.
+token whose scope satisfies `operation="commit"` and matches `repo_path` and `ref`. A capability minted for `tag` or `push` is rejected.
 
 ```json
 {
@@ -295,12 +338,11 @@ token whose scope satisfies `operation=write` and matches `repo_path`.
   },
   "output_schema": {
     "type": "object",
-    "required": ["signature", "signing_key_op", "key_fingerprint"],
+    "required": ["signature", "key_fingerprint"],
     "additionalProperties": false,
     "properties": {
       "signature":       { "type": "string", "description": "ASCII-armored signature block." },
-      "signing_key_op":  { "type": "string", "description": "1Password op:// reference used (not the key)." },
-      "key_fingerprint": { "type": "string" }
+      "key_fingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "SHA-256 hex digest of the signing public key. Non-sensitive identifier; safe to log. The actual signing key reference (op:// path / 1Password UUID) is broker-internal and MUST NEVER appear in any response, ledger payload, or error envelope." }
     }
   }
 }
@@ -308,7 +350,7 @@ token whose scope satisfies `operation=write` and matches `repo_path`.
 
 #### `[SPEC] POST /api/v1/signing/sign-tag`
 
-Same shape as `sign-commit` but signs an annotated-tag object payload.
+Same shape as `sign-commit` but signs an annotated-tag object payload. The presented capability MUST have `operation="tag"` and matching `repo_path` + `ref`; capabilities for `commit` or `push` are rejected.
 
 ```json
 {
@@ -325,12 +367,11 @@ Same shape as `sign-commit` but signs an annotated-tag object payload.
   },
   "output_schema": {
     "type": "object",
-    "required": ["signature", "signing_key_op", "key_fingerprint"],
+    "required": ["signature", "key_fingerprint"],
     "additionalProperties": false,
     "properties": {
       "signature":       { "type": "string" },
-      "signing_key_op":  { "type": "string" },
-      "key_fingerprint": { "type": "string" }
+      "key_fingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "SHA-256 hex digest of the signing public key. Non-sensitive; safe to log." }
     }
   }
 }
@@ -351,7 +392,7 @@ default author identity. Called by the resource server during admission.
     "properties": {
       "tenant_id":       { "type": "string" },
       "caller_chittyid": { "type": "string" },
-      "operation":       { "type": "string", "enum": ["read", "write"] }
+      "operation":       { "type": "string", "enum": ["read", "commit", "tag", "push"] }
     }
   },
   "output_schema": {
@@ -415,7 +456,7 @@ client. Domain tag is fixed to `git` on this surface.
 7. **Credential redaction (binding contract)** — any string the resource server places in a `ledger.emit` payload or any error envelope it returns to the client MUST pass through a redaction filter:
    - URL userinfo: strip the `userinfo` component from any URL, rewriting `https?://[^@]+@` to scheme-only `https?://`. Applies to remote URLs and any URL in error messages.
    - CLI output: omit raw `git` stdout/stderr from error envelopes, or pass it through the userinfo strip plus a token-pattern scrub (`gh[pousr]_[A-Za-z0-9_]{20,}`, `github_pat_[A-Za-z0-9_]{20,}`, `xox[bpars]-[A-Za-z0-9-]{10,}`, 40+ char hex/base64 secrets adjacent to `://` or `Authorization:`). When in doubt, omit.
-   - Capability tokens, confirmation tokens, signatures, and signing-key references MUST NEVER appear in ledger payloads or error envelopes.
+   - Capability tokens, confirmation tokens, signatures, and signing-key references (op:// paths, 1Password UUIDs, secret names, env-var names referencing keys) MUST NEVER appear in any broker response (including `/signing/*` outputs), ledger payloads, or error envelopes. Only the non-sensitive `key_fingerprint` (sha256 of the public key) is exported.
 
 #### Error codes
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -111,95 +111,66 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 - `chitty_services_status` - Monitor ecosystem health
 - `chitty_finance_connect_bank` - Connect banking
 
-#### Planned (Spec)
-> The following tools are spec-only — not yet present in the `MCP_TOOLS` registry.
-> Implementation tracked in chittyos/chittyconnect#209. See "Git Tool Surface" below
-> for full schemas and policy gates.
-
-- `[SPEC] git_commit` - Create signed commit in an allowlisted repo (policy-gated)
-- `[SPEC] git_push` - Push to an allowlisted remote (policy-gated, force operations require second-factor)
-- `[SPEC] git_tag` - Create signed tag at a ref (policy-gated)
-
-### Git Tool Surface (write/sensitive) — SPEC
-
-> **Status: SPEC** — these tools are NOT YET IMPLEMENTED. They are not present in
-> the `MCP_TOOLS` registry. Implementation tracked in chittyos/chittyconnect#209.
+> **Note (2026-06):** Prior revisions of this CHARTER proposed adding `git_commit`,
+> `git_push`, `git_tag` as MCP tools here. That framing is **withdrawn**.
+> ChittyConnect is a **broker** (authorization server + credential broker), not an
+> MCP tool host. All `git_*` MCP tools (read and write) live on `chittyagent-git`
+> (the resource server). ChittyConnect exposes **REST broker primitives** that the
+> resource server calls into. See "Git Broker Surface (REST, sensitive)" below.
 >
-> Read-only git tools (`git_status`, `git_log`, `git_diff`, `git_show`, `git_blame`,
-> `git_branch_list`) live on chittymcp via the `chittyagent-git` upstream. Write
-> tools are spec'd here on ChittyConnect because they fall under the sensitive-intent
-> contract (`~/.ch1tty/canon/system-wide-sensitive-intent-contract-v1.md`) and
-> require OAuth + 1Password-zerotrust + ChittyLedger audit.
->
-> **Signing is mandatory and non-overridable** for `git_commit` and `git_tag` —
-> the input schema deliberately omits a `sign` field so clients cannot disable it.
-> The implementation MUST sign every commit and tag.
+> The legacy `/mcp/*` endpoints on this service are deprecated and slated for
+> removal; do not extend them.
 
-#### `[SPEC] git_commit`
+### Git Broker Surface (REST, sensitive) — SPEC
+
+> **Status: SPEC** — these REST broker primitives are NOT YET IMPLEMENTED.
+> Implementation tracked in chittyos/chittyconnect#209.
+>
+> **Architecture (binding).** ChittyConnect is an **authorization server +
+> credential broker**, not an MCP tool host. The MCP surface for git lives on
+> `chittyagent-git` (the resource server, Cloudflare Worker in `chittyentity`),
+> which exposes ALL git tools — both read (`git_status`, `git_log`, `git_diff`,
+> `git_show`, `git_blame`, `git_branch_list`) and write (`git_commit`,
+> `git_push`, `git_tag`). `chittymcp` / `ch1tty` federate that worker for
+> discovery + transport but carry no policy.
+>
+> The endpoints below are the broker primitives the resource server calls
+> *back* into. ChittyConnect never sits on the client→worker call path:
+> the client carries a capability token, the worker validates it here and
+> requests signing / ledger emission as needed.
+>
+> **Signing is mandatory and non-overridable** for commit and tag operations.
+> Signing keys are resolved from 1Password and never leave the broker; only
+> the produced signature is returned.
+
+#### `[SPEC] POST /api/v1/capabilities/mint`
+
+Mint a short-TTL capability token scoped to a single caller × tenant × repo ×
+operation. Tokens are opaque to clients; their claims are obtained via
+`introspect`. For `operation = "write"` with `force_class != "none"`, a fresh
+confirmation token from `/api/v1/capabilities/confirm` is required.
 
 ```json
 {
-  "name": "git_commit",
-  "description": "Create a signed commit in an allowlisted local repo. Signing is mandatory and non-overridable. Signing key resolved from 1Password; never from env or disk plaintext.",
+  "name": "capabilities.mint",
   "input_schema": {
     "type": "object",
-    "required": ["repo_path", "message"],
+    "required": ["caller_chittyid", "tenant_id", "operation", "repo_path"],
     "additionalProperties": false,
     "properties": {
-      "repo_path":  { "type": "string", "description": "Absolute path; must match CHITTYCONNECT_GIT_REPO_ROOTS allowlist." },
-      "message":    { "type": "string", "minLength": 1, "maxLength": 4096 },
-      "paths":      { "type": "array",  "items": { "type": "string" }, "description": "Optional explicit paths; defaults to all staged." },
-      "author":     { "type": "string", "description": "Optional 'Name <email>' override; subject to author allowlist." }
-    }
-  },
-  "output_schema": {
-    "type": "object",
-    "required": ["commit_sha", "signed", "ledger_event_id"],
-    "properties": {
-      "commit_sha":      { "type": "string" },
-      "signed":          { "type": "boolean", "const": true, "description": "Always true — signing is mandatory." },
-      "signing_key_op":  { "type": "string", "description": "1Password op:// reference used (not the key)." },
-      "ledger_event_id": { "type": "string" }
-    }
-  }
-}
-```
-
-#### `[SPEC] git_push`
-
-```json
-{
-  "name": "git_push",
-  "description": "Push a ref to an allowlisted remote. Force operations require explicit second-factor confirmation. force and force_with_lease are mutually exclusive; either one requires a confirmation_token. Force-push to main/master is hard-denied.",
-  "input_schema": {
-    "type": "object",
-    "required": ["repo_path", "ref"],
-    "additionalProperties": false,
-    "properties": {
-      "repo_path":         { "type": "string" },
-      "remote":            { "type": "string", "default": "origin" },
-      "ref":               { "type": "string", "description": "Local ref or refspec." },
-      "force":             { "type": "boolean", "default": false },
-      "force_with_lease":  { "type": "boolean", "default": false },
-      "confirmation_token":{ "type": "string", "description": "Required when force=true OR force_with_lease=true. Short-lived token from ChittyConnect's confirm endpoint." }
+      "caller_chittyid":    { "type": "string", "pattern": "^[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]{3}-[A-Z0-9]{4}-[PLTEA]-[A-Z0-9]{2}-[A-Z0-9]-[A-Z0-9]$" },
+      "tenant_id":          { "type": "string", "minLength": 1, "maxLength": 128 },
+      "operation":          { "type": "string", "enum": ["read", "write"] },
+      "repo_path":          { "type": "string", "minLength": 1, "description": "Absolute path; validated against tenant repo allowlist." },
+      "remote":             { "type": "string", "description": "Required when operation=write and the downstream call is a push." },
+      "force_class":        { "type": "string", "enum": ["none", "force", "force_with_lease"], "default": "none" },
+      "confirmation_token": { "type": "string", "description": "Required when force_class != 'none'." }
     },
     "allOf": [
       {
-        "not": {
-          "type": "object",
-          "properties": {
-            "force":            { "const": true },
-            "force_with_lease": { "const": true }
-          },
-          "required": ["force", "force_with_lease"]
-        }
-      },
-      {
         "if": {
-          "anyOf": [
-            { "type": "object", "properties": { "force":            { "const": true } }, "required": ["force"] },
-            { "type": "object", "properties": { "force_with_lease": { "const": true } }, "required": ["force_with_lease"] }
-          ]
+          "properties": { "force_class": { "enum": ["force", "force_with_lease"] } },
+          "required": ["force_class"]
         },
         "then": { "required": ["confirmation_token"] }
       }
@@ -207,41 +178,227 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
   },
   "output_schema": {
     "type": "object",
-    "required": ["remote_url", "pushed_refs", "ledger_event_id"],
+    "required": ["token", "token_type", "expires_at", "scope"],
+    "additionalProperties": false,
     "properties": {
-      "remote_url":      { "type": "string", "description": "REDACTED form of the remote URL — userinfo (any embedded credentials matching https?://[^@]+@) MUST be stripped before return. Example: https://github.com/owner/repo.git (never https://TOKEN@github.com/...)." },
-      "pushed_refs":     { "type": "array", "items": { "type": "string" } },
-      "ledger_event_id": { "type": "string" }
+      "token":      { "type": "string", "description": "Opaque capability token. MUST NOT be logged or echoed in error envelopes." },
+      "token_type": { "type": "string", "const": "chittyconnect-capability" },
+      "expires_at": { "type": "string", "format": "date-time", "description": "TTL <= 300s." },
+      "scope": {
+        "type": "object",
+        "required": ["caller_chittyid", "tenant_id", "operation", "repo_path"],
+        "additionalProperties": false,
+        "properties": {
+          "caller_chittyid": { "type": "string" },
+          "tenant_id":       { "type": "string" },
+          "operation":       { "type": "string", "enum": ["read", "write"] },
+          "repo_path":       { "type": "string" },
+          "remote":          { "type": "string" },
+          "force_class":     { "type": "string", "enum": ["none", "force", "force_with_lease"] }
+        }
+      }
     }
   }
 }
 ```
 
-#### `[SPEC] git_tag`
+#### `[SPEC] POST /api/v1/capabilities/introspect`
+
+Validate a capability token and return its claims. Resource servers
+(`chittyagent-git`) call this on every inbound request before performing any
+git operation. Fail-closed if unreachable.
 
 ```json
 {
-  "name": "git_tag",
-  "description": "Create a signed annotated tag at a ref. Signing is mandatory and non-overridable.",
+  "name": "capabilities.introspect",
   "input_schema": {
     "type": "object",
-    "required": ["repo_path", "name", "message"],
+    "required": ["token"],
+    "additionalProperties": false,
+    "properties": { "token": { "type": "string" } }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["active"],
     "additionalProperties": false,
     "properties": {
-      "repo_path": { "type": "string" },
-      "name":      { "type": "string", "pattern": "^(?!-)[A-Za-z0-9._/-]+$", "description": "Tag name. MUST NOT start with '-' to prevent option-injection if the implementation shells out to git." },
-      "ref":       { "type": "string", "default": "HEAD" },
-      "message":   { "type": "string", "minLength": 1 }
+      "active":     { "type": "boolean" },
+      "expires_at": { "type": "string", "format": "date-time" },
+      "scope": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "caller_chittyid": { "type": "string" },
+          "tenant_id":       { "type": "string" },
+          "operation":       { "type": "string", "enum": ["read", "write"] },
+          "repo_path":       { "type": "string" },
+          "remote":          { "type": "string" },
+          "force_class":     { "type": "string", "enum": ["none", "force", "force_with_lease"] }
+        }
+      }
+    }
+  }
+}
+```
+
+#### `[SPEC] POST /api/v1/capabilities/confirm`
+
+Issue a short-TTL confirmation token. Required as a second factor before
+minting a capability with `force_class != "none"`. Confirmation tokens are
+single-use and bound to caller+tenant+repo+force_class.
+
+```json
+{
+  "name": "capabilities.confirm",
+  "input_schema": {
+    "type": "object",
+    "required": ["caller_chittyid", "tenant_id", "repo_path", "force_class"],
+    "additionalProperties": false,
+    "properties": {
+      "caller_chittyid": { "type": "string" },
+      "tenant_id":       { "type": "string" },
+      "repo_path":       { "type": "string" },
+      "force_class":     { "type": "string", "enum": ["force", "force_with_lease"] }
     }
   },
   "output_schema": {
     "type": "object",
-    "required": ["tag_name", "object_sha", "signed", "ledger_event_id"],
+    "required": ["confirmation_token", "expires_at"],
+    "additionalProperties": false,
     "properties": {
-      "tag_name":        { "type": "string" },
-      "object_sha":      { "type": "string" },
-      "signed":          { "type": "boolean", "const": true, "description": "Always true — signing is mandatory." },
-      "ledger_event_id": { "type": "string" }
+      "confirmation_token": { "type": "string" },
+      "expires_at":         { "type": "string", "format": "date-time", "description": "TTL <= 120s." }
+    }
+  }
+}
+```
+
+#### `[SPEC] POST /api/v1/signing/sign-commit`
+
+Produce a detached signature over the canonical commit payload supplied by the
+resource server. The signing key (resolved from 1Password by the broker) never
+leaves ChittyConnect. The resource server MUST present a valid capability
+token whose scope satisfies `operation=write` and matches `repo_path`.
+
+```json
+{
+  "name": "signing.sign-commit",
+  "input_schema": {
+    "type": "object",
+    "required": ["capability_token", "repo_path", "commit_payload"],
+    "additionalProperties": false,
+    "properties": {
+      "capability_token": { "type": "string" },
+      "repo_path":        { "type": "string" },
+      "commit_payload":   { "type": "string", "description": "Canonical pre-signature commit object bytes (tree, parents, author, committer, message), base64-encoded." }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["signature", "signing_key_op", "key_fingerprint"],
+    "additionalProperties": false,
+    "properties": {
+      "signature":       { "type": "string", "description": "ASCII-armored signature block." },
+      "signing_key_op":  { "type": "string", "description": "1Password op:// reference used (not the key)." },
+      "key_fingerprint": { "type": "string" }
+    }
+  }
+}
+```
+
+#### `[SPEC] POST /api/v1/signing/sign-tag`
+
+Same shape as `sign-commit` but signs an annotated-tag object payload.
+
+```json
+{
+  "name": "signing.sign-tag",
+  "input_schema": {
+    "type": "object",
+    "required": ["capability_token", "repo_path", "tag_payload"],
+    "additionalProperties": false,
+    "properties": {
+      "capability_token": { "type": "string" },
+      "repo_path":        { "type": "string" },
+      "tag_payload":      { "type": "string", "description": "Canonical pre-signature tag object bytes, base64-encoded." }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["signature", "signing_key_op", "key_fingerprint"],
+    "additionalProperties": false,
+    "properties": {
+      "signature":       { "type": "string" },
+      "signing_key_op":  { "type": "string" },
+      "key_fingerprint": { "type": "string" }
+    }
+  }
+}
+```
+
+#### `[SPEC] POST /api/v1/policy/resolve`
+
+Resolve tenant policy: allowed repos, allowed remotes, force-push gates,
+default author identity. Called by the resource server during admission.
+
+```json
+{
+  "name": "policy.resolve",
+  "input_schema": {
+    "type": "object",
+    "required": ["tenant_id", "caller_chittyid", "operation"],
+    "additionalProperties": false,
+    "properties": {
+      "tenant_id":       { "type": "string" },
+      "caller_chittyid": { "type": "string" },
+      "operation":       { "type": "string", "enum": ["read", "write"] }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["allowed_repos", "allowed_remotes", "force_push_allowed", "protected_branches"],
+    "additionalProperties": false,
+    "properties": {
+      "allowed_repos":      { "type": "array", "items": { "type": "string" }, "description": "Absolute path globs." },
+      "allowed_remotes":    { "type": "array", "items": { "type": "string" }, "description": "URL globs (e.g. github.com/CHITTYOS/*)." },
+      "force_push_allowed": { "type": "boolean" },
+      "protected_branches": { "type": "array", "items": { "type": "string" }, "description": "Branches where force-push is hard-denied regardless of confirmation." },
+      "default_author":     { "type": "string", "description": "'Name <email>' applied when caller does not override." }
+    }
+  }
+}
+```
+
+#### `[SPEC] POST /api/v1/ledger/emit`
+
+Emit a domain-tagged ChittyLedger event from the resource server. Returns the
+ledger entry hash for inclusion in the resource server's response to the
+client. Domain tag is fixed to `git` on this surface.
+
+```json
+{
+  "name": "ledger.emit",
+  "input_schema": {
+    "type": "object",
+    "required": ["capability_token", "event_type", "payload"],
+    "additionalProperties": false,
+    "properties": {
+      "capability_token": { "type": "string" },
+      "event_type":       { "type": "string", "enum": ["git.commit", "git.push", "git.tag"] },
+      "payload": {
+        "type": "object",
+        "description": "Event-specific fields (commit_sha, pushed_refs, tag_name, etc.). MUST NOT contain raw remote URLs with userinfo or raw git stderr — apply the redaction contract before submitting."
+      }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["ledger_event_id", "entry_hash", "domain"],
+    "additionalProperties": false,
+    "properties": {
+      "ledger_event_id": { "type": "string" },
+      "entry_hash":      { "type": "string", "description": "Hex sha256 of the canonicalized entry." },
+      "domain":          { "type": "string", "const": "git" }
     }
   }
 }
@@ -249,29 +406,31 @@ ChittyConnect is the **AI-intelligent spine** (itsChitty™) for the ChittyOS ec
 
 #### Policy gates (binding)
 
-1. **Signing key** — resolved from 1Password via `op://` reference per the sensitive-intent contract. Never read from env vars, disk, or chat. Signing is mandatory for `git_commit` and `git_tag`; the input schemas omit any disable knob. If 1Password is unreachable → fail closed.
-2. **Remote allowlist** — per-tenant config. Default allowlist: `github.com/CHITTYOS/*`, `github.com/CHITTYFOUNDATION/*`. Pushes to non-allowlisted remotes → `POLICY_BLOCKED_REMOTE_NOT_ALLOWED`.
-3. **Repo allowlist** — `CHITTYCONNECT_GIT_REPO_ROOTS` env (cold-source: 1Password). Repos outside → `POLICY_BLOCKED_REPO_NOT_ALLOWED`.
-4. **Force-push guard** — `force=true` OR `force_with_lease=true` requires a fresh `confirmation_token` from `POST /api/git/confirm` (same risk class — both can overwrite remote history). Setting both flags true is rejected at the schema layer. Force-push to `main` or `master` (or repo default branch) is hard-denied regardless of token → `POLICY_BLOCKED_FORCE_TO_PROTECTED`.
-5. **Audit** — every successful write emits a ChittyLedger event (domain-tagged `git`, hash-chained per the canonical projection model). The `ledger_event_id` is returned in the response.
-6. **Broker liveness** — if the policy broker is unreachable, fail closed with `POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE`. No local fallback.
-7. **Credential redaction (binding contract)** — any string returned to the caller that may have originated from a git remote URL or git CLI output MUST pass through a redaction filter before serialization:
-   - URL userinfo: the implementation MUST strip the `userinfo` component from any URL, rewriting `https?://[^@]+@` to the scheme-only prefix `https?://`. This applies to the `remote_url` output field and to any URL appearing in error messages.
-   - CLI output: the implementation MUST either omit raw `git` stdout/stderr from error envelopes or pass it through the same userinfo-stripping filter plus a token-pattern scrub (common Git provider PAT/OAuth patterns, e.g. `gh[pousr]_[A-Za-z0-9_]{20,}`, `github_pat_[A-Za-z0-9_]{20,}`, `xox[bpars]-[A-Za-z0-9-]{10,}`, generic 40+ char hex/base64 secrets adjacent to `://` or `Authorization:`). When in doubt, omit.
+1. **Signing key** — resolved from 1Password via `op://` reference per the sensitive-intent contract. Never read from env vars, disk, or chat. Signing is mandatory for commit and tag flows; broker exposes no disable knob. If 1Password is unreachable → fail closed.
+2. **Remote allowlist** — per-tenant config returned by `policy.resolve`. Default: `github.com/CHITTYOS/*`, `github.com/CHITTYFOUNDATION/*`. Resource server MUST refuse push to non-allowlisted remotes → `POLICY_BLOCKED_REMOTE_NOT_ALLOWED`.
+3. **Repo allowlist** — per-tenant. Resource server MUST refuse repos outside the list → `POLICY_BLOCKED_REPO_NOT_ALLOWED`.
+4. **Force-push guard** — minting a capability with `force_class != "none"` requires a fresh `confirmation_token` from `/api/v1/capabilities/confirm`. Confirmation tokens are single-use and bound to (caller, tenant, repo, force_class). Force-push to any branch in `protected_branches` is hard-denied regardless of token → `POLICY_BLOCKED_FORCE_TO_PROTECTED`. `force` and `force_with_lease` are distinct values of `force_class` — they cannot be combined.
+5. **Audit** — every successful write requires the resource server to call `/api/v1/ledger/emit`. The returned `ledger_event_id` is included in the response to the client. Domain tag is `git`, hash-chained per the canonical projection model.
+6. **Broker liveness** — if the broker is unreachable from the resource server, the resource server fails closed with `POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE`. No local fallback.
+7. **Credential redaction (binding contract)** — any string the resource server places in a `ledger.emit` payload or any error envelope it returns to the client MUST pass through a redaction filter:
+   - URL userinfo: strip the `userinfo` component from any URL, rewriting `https?://[^@]+@` to scheme-only `https?://`. Applies to remote URLs and any URL in error messages.
+   - CLI output: omit raw `git` stdout/stderr from error envelopes, or pass it through the userinfo strip plus a token-pattern scrub (`gh[pousr]_[A-Za-z0-9_]{20,}`, `github_pat_[A-Za-z0-9_]{20,}`, `xox[bpars]-[A-Za-z0-9-]{10,}`, 40+ char hex/base64 secrets adjacent to `://` or `Authorization:`). When in doubt, omit.
+   - Capability tokens, confirmation tokens, signatures, and signing-key references MUST NEVER appear in ledger payloads or error envelopes.
 
 #### Error codes
 
 | Code | Meaning |
 |------|---------|
-| `POLICY_BLOCKED_REPO_NOT_ALLOWED` | `repo_path` not in allowlist |
+| `POLICY_BLOCKED_REPO_NOT_ALLOWED` | `repo_path` not in tenant repo allowlist |
 | `POLICY_BLOCKED_REMOTE_NOT_ALLOWED` | Remote URL not in tenant allowlist |
 | `POLICY_BLOCKED_FORCE_TO_PROTECTED` | Force-push attempted against protected branch |
-| `POLICY_BLOCKED_CONFIRMATION_REQUIRED` | `force=true` or `force_with_lease=true` without valid `confirmation_token` |
-| `POLICY_BLOCKED_FORCE_FLAGS_CONFLICT` | Both `force` and `force_with_lease` set true (schema-level reject) |
+| `POLICY_BLOCKED_CONFIRMATION_REQUIRED` | `force_class != "none"` without valid `confirmation_token` |
+| `POLICY_BLOCKED_CONFIRMATION_INVALID` | Confirmation token expired, reused, or scope-mismatched |
+| `POLICY_BLOCKED_CAPABILITY_INVALID` | Capability token expired, malformed, or scope-mismatched |
 | `POLICY_BLOCKED_SIGNING_KEY_UNAVAILABLE` | 1Password unreachable or key missing |
-| `POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE` | Policy broker unreachable; fail closed |
-| `GIT_DIRTY_INDEX` | Commit attempted with no staged changes and no `paths` |
-| `GIT_REMOTE_REJECTED` | Underlying `git push` returned non-zero. Any embedded output MUST be redacted per the Credential redaction contract above (userinfo stripped, token patterns scrubbed); when in doubt, the implementation omits raw output and returns only the exit code. |
+| `POLICY_BLOCKED_CHITTYCONNECT_UNAVAILABLE` | Broker unreachable; resource server fails closed |
+| `GIT_DIRTY_INDEX` | Commit attempted with no staged changes and no `paths` (raised at resource server) |
+| `GIT_REMOTE_REJECTED` | Underlying push returned non-zero. Embedded output MUST be redacted per the contract above; when in doubt the resource server omits raw output and returns only the exit code. |
 
 ### Authentication
 ```

--- a/CHITTY.md
+++ b/CHITTY.md
@@ -44,7 +44,7 @@ Source: `chittycanon://gov/governance#three-aspects`
 | Aspect | Abbrev | Answer |
 |--------|--------|--------|
 | **Identity** | TY | AI-intelligent spine — universal connector for GPTs, Claude, and third-party integrations |
-| **Connectivity** | VY | REST API + MCP Server + GitHub App; proxies Notion, OpenAI, Neon, Google Calendar; ContextConsciousness cross-session state; policy-gated git write tools (`git_commit`, `git_push`, `git_tag`) **planned** for non-shell channels — spec-only, see CHARTER §"Git Tool Surface (write/sensitive) — SPEC", tracking chittyos/chittyconnect#209 (read-only git on chittymcp via `chittyagent-git`) |
+| **Connectivity** | VY | REST API + GitHub App; proxies Notion, OpenAI, Neon, Google Calendar; ContextConsciousness cross-session state. Acts as authorization server (capability minting/introspection, confirmation) + credential broker (signing-as-a-service from 1Password) + policy resolver + ledger emitter for the git tool surface — the MCP surface for git lives on `chittyagent-git` (resource server), not here. See CHARTER §"Git Broker Surface (REST, sensitive) — SPEC"; tracking chittyos/chittyconnect#209. |
 | **Authority** | RY | Tier 2 Platform — integration hub, not source of truth; delegates identity/auth/registration upstream |
 
 ## ChittyOS Ecosystem


### PR DESCRIPTION
## Summary

Corrects the architectural framing shipped in #208. ChittyConnect is the **authorization server + credential broker**, not an MCP tool host. The MCP surface for git (read AND write) belongs on `chittyagent-git` (resource server, CF Worker in chittyentity); `chittymcp` / `ch1tty` federate that worker for discovery + transport but carry no policy.

PR #208 merged with `git_commit` / `git_push` / `git_tag` registered as MCP tools on ChittyConnect, which is wrong. This PR removes that framing and replaces it with a REST broker surface that the resource server calls back into for capability minting, signing, policy resolution, and ledger emission.

## Changes (docs-only)

- **CHARTER.md**: Replace "Git Tool Surface (write/sensitive) — SPEC" (MCP framing) with "Git Broker Surface (REST, sensitive) — SPEC" defining 7 endpoints:
  - `POST /api/v1/capabilities/mint` — scoped capability token issuance
  - `POST /api/v1/capabilities/introspect` — token validation + scope claims
  - `POST /api/v1/capabilities/confirm` — confirmation token for force-class operations
  - `POST /api/v1/signing/sign-commit` — sign commit object (keys never leave broker)
  - `POST /api/v1/signing/sign-tag` — sign tag object
  - `POST /api/v1/policy/resolve` — tenant policy lookup (allowed repos/remotes/force gates)
  - `POST /api/v1/ledger/emit` — emit to ChittyLedger, domain tag `git`
  - Each endpoint has full JSON Schema (input + output, `additionalProperties: false`), policy gates, and error codes.
  - Redaction contract preserved: capability tokens, confirmation tokens, signatures, and signing-key refs MUST NEVER appear in ledger payloads or error envelopes.
  - Force-push confirmation flow: `capabilities/mint` with `force=true` requires a fresh confirmation token from `capabilities/confirm`.
- **CHITTY.md**: VY/Connectivity row updated — ChittyConnect provides REST broker primitives for git; MCP framing removed.
- **No src/index.js changes** — pure spec / docs.

## Architecture (correct)

```
client → chittymcp/ch1tty (federation) → chittyagent-git (RS, MCP tools)
                                                |
                                                v (capability token validate, sign, ledger)
                                         ChittyConnect (AS, REST broker)
```

ChittyConnect never sits on the client→worker call path.

## Validation

ajv-compile of all schemas: **14/14 pass** (7 endpoints × input+output, ajv 8.x with ajv-formats, `strict: false, allErrors: true`).

## Followup (not in this PR)

The 6 implementation issues from the original architecture need to be reframed in a separate orchestration pass:
- chittyconnect#209, #210, #211
- chittyentity#309
- chittymcp#111
- chittyfoundation/chittyledger#11

They are intentionally left untouched so the followup can be a single coherent orchestration.

## Test plan

- [x] Diff is docs-only (CHARTER.md + CHITTY.md)
- [x] All JSON schemas ajv-compile cleanly
- [x] No `git_*` MCP tools registered on ChittyConnect
- [x] No extensions to `/mcp/*` endpoints
- [ ] Reviewer confirms broker REST surface matches existing `/api/git/*` patterns and 1Password key-resolution conventions
- [ ] Reviewer confirms redaction contract sufficient for ledger payloads

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>