### PR TITLE
fix(secrets): catalog NEON_API_KEY (G7 root-cause)

### DIFF
--- a/.github/secret-catalog.json
+++ b/.github/secret-catalog.json
@@ -156,6 +156,13 @@
       "vault": "ChittyOS",
       "rotation_days": 90,
       "scope": "service-auth"
+    },
+    {
+      "name": "NEON_API_KEY",
+      "source": "1password",
+      "vault": "ChittyOS",
+      "rotation_days": 90,
+      "scope": "third-party"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `NEON_API_KEY` to `.github/secret-catalog.json` — the root-cause fix for **finding G7**. This is a **pure catalog metadata entry**; no secret value is touched anywhere.

## Finding G7 — evidence

- `secret:neon:meta.lastResult = error` since **2026-06-10** — the DB-password rotator fails with **"Missing Neon API credentials"**.
- `NEON_API_KEY` was **absent from the catalog** entirely (only `NEON_DATABASE_URL`, the Postgres connection string / data-plane credential, was present).
- Per the operator's G7 finding, the key is **untracked by `onepassword-rotation-audit.yml`**. (Note: the audit workflow as written counts catalog entries and warns on `null` `rotation_days`; it does not enumerate per-secret against 1Password — the per-secret tracking gap is the operator's stated evidence, surfaced here for context.)

## What this entry does

```json
{
  "name": "NEON_API_KEY",
  "source": "1password",
  "vault": "ChittyOS",
  "rotation_days": 90,
  "scope": "third-party"
}
```

- **Scope `third-party`**: `NEON_API_KEY` is a control-plane SaaS API key for the Neon platform — same credential class as `OPENAI_API_KEY` and `NOTION_API_KEY` (both `third-party`). It is deliberately **not** `database` scope; that scope belongs to `NEON_DATABASE_URL` (the data-plane connection string). The task suggested scope `integration-api-key`, but that value exists nowhere in the catalog or repo — per the "match the file, don't invent" constraint, the existing `third-party` convention is used. The broker destination (`integrations/neon/...`) confirms the integration/third-party bucket.
- **`rotation_days: 90`**: matches `OPENAI_API_KEY` exactly (rotatable third-party API key).

## Why this unblocks downstream

1. **rotation-audit tracking** — the key is now a first-class catalog entry with a 90-day schedule.
2. **Prerequisite** for the out-of-band Neon **account-key console rotation** (operator-only — not performed here).
3. **Prerequisite** for the `sync-1p-to-cf-secrets` → CF Secrets path.

**Broker destination:** 1Password `ChittyOS :: integrations/neon/api_key`.

## Validation

```
$ jq empty .github/secret-catalog.json   # exact check rotation-audit runs
JSON_VALID
$ jq '.secrets | length'  →  23   (was 22)
```

## Scope guardrails honored

- Catalog metadata only — **no secret value**, no rotation, no KV mutation, no secret write.
- Did **not** touch `.github/allowed-workflow-secrets.txt`, `version`, or `last_audit` (out of scope for this entry). If rotation-audit "tracking" should also gate on the allowed-workflow-secrets list, that is a **follow-up**, not part of this diff.

## CI note

Husky bootstrap (`.husky/_/husky.sh`) is **absent in this environment**, so both `pre-commit` and `pre-push` hooks error. `lint-staged` was run manually (no staged files in its glob; catalog JSON validated via `jq empty`). Commit and push used `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)