### PR TITLE
fix(google): shared-drive params on Drive v3 proxy (Bug 2)

### DIFF
--- a/src/api/routes/google.js
+++ b/src/api/routes/google.js
@@ -94,8 +94,10 @@ googleRoutes.get("/gdrive/files", async (c) => {
   if (fields) params.set("fields", fields);
   if (pageSize) params.set("pageSize", pageSize);
   if (pageToken) params.set("pageToken", pageToken);
-  // Shared-drive support: without these, files living in shared drives are
-  // invisible to list/get even when the delegated user is a member.
+  // Shared-drive support for files.list: supportsAllDrives, includeItemsFromAllDrives,
+  // and corpora are all required here; the latter two are list-only params and are
+  // not forwarded to files.get or download calls. supportsAllDrives is also set on
+  // those routes separately.
   params.set("supportsAllDrives", "true");
   params.set("includeItemsFromAllDrives", "true");
   params.set("corpora", "allDrives");

--- a/src/api/routes/google.js
+++ b/src/api/routes/google.js
@@ -94,6 +94,11 @@ googleRoutes.get("/gdrive/files", async (c) => {
   if (fields) params.set("fields", fields);
   if (pageSize) params.set("pageSize", pageSize);
   if (pageToken) params.set("pageToken", pageToken);
+  // Shared-drive support: without these, files living in shared drives are
+  // invisible to list/get even when the delegated user is a member.
+  params.set("supportsAllDrives", "true");
+  params.set("includeItemsFromAllDrives", "true");
+  params.set("corpora", "allDrives");
 
   const result = await googleProxy(c.env, `${DRIVE_API}/files?${params.toString()}`, { scope: "drive" });
   if (!result.ok) return c.json({ error: result.error }, result.status);
@@ -110,6 +115,8 @@ googleRoutes.get("/gdrive/files/:fileId", async (c) => {
 
   const params = new URLSearchParams();
   if (fields) params.set("fields", fields);
+  // Shared-drive support — required for files that live in a shared drive.
+  params.set("supportsAllDrives", "true");
 
   const encodedFileId = encodeURIComponent(fileId);
   const result = await googleProxy(c.env, `${DRIVE_API}/files/${encodedFileId}?${params.toString()}`, { scope: "drive" });
@@ -130,7 +137,7 @@ googleRoutes.get("/gdrive/files/:fileId/content", async (c) => {
 
   // First, fetch file metadata to determine mimeType
   const encodedFileId = encodeURIComponent(fileId);
-  const metadataResponse = await fetch(`${DRIVE_API}/files/${encodedFileId}?fields=mimeType`, {
+  const metadataResponse = await fetch(`${DRIVE_API}/files/${encodedFileId}?fields=mimeType&supportsAllDrives=true`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -152,10 +159,10 @@ googleRoutes.get("/gdrive/files/:fileId/content", async (c) => {
   if (googleNativeTypes.includes(mimeType)) {
     // Use export endpoint for Google-native files (export as PDF by default)
     const exportMimeType = encodeURIComponent("application/pdf");
-    downloadUrl = `${DRIVE_API}/files/${encodedFileId}/export?mimeType=${exportMimeType}`;
+    downloadUrl = `${DRIVE_API}/files/${encodedFileId}/export?mimeType=${exportMimeType}&supportsAllDrives=true`;
   } else {
     // Use alt=media for binary-backed files
-    downloadUrl = `${DRIVE_API}/files/${encodedFileId}?alt=media`;
+    downloadUrl = `${DRIVE_API}/files/${encodedFileId}?alt=media&supportsAllDrives=true`;
   }
 
   const response = await fetch(downloadUrl, {

--- a/tests/api/google-routes.test.js
+++ b/tests/api/google-routes.test.js
@@ -213,6 +213,16 @@ describe("GET /gdrive/files", () => {
     expect(url).toContain("https://www.googleapis.com/drive/v3/files");
   });
 
+  it("always sets shared-drive params on the upstream files.list URL", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ files: [] }));
+    await get("/gdrive/files", env);
+    const [url] = globalThis.fetch.mock.calls[0];
+    const params = new URL(url).searchParams;
+    expect(params.get("supportsAllDrives")).toBe("true");
+    expect(params.get("includeItemsFromAllDrives")).toBe("true");
+    expect(params.get("corpora")).toBe("allDrives");
+  });
+
   it("forwards q query parameter to Google API", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ files: [] }));
     await get("/gdrive/files", env, "q=name+contains+'report'");
@@ -301,6 +311,13 @@ describe("GET /gdrive/files/:fileId", () => {
     expect(url).toContain("fields=");
   });
 
+  it("includes supportsAllDrives=true on the upstream files.get URL", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse({ id: "f1" }));
+    await get("/gdrive/files/f1", env);
+    const [url] = globalThis.fetch.mock.calls[0];
+    expect(new URL(url).searchParams.get("supportsAllDrives")).toBe("true");
+  });
+
   it("returns 404 when Google returns 404", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(404, "File not found"));
     const res = await get("/gdrive/files/missing", env);
@@ -367,6 +384,32 @@ describe("GET /gdrive/files/:fileId/content", () => {
     expect(res.status).toBe(200);
     const [exportUrl] = globalThis.fetch.mock.calls[1];
     expect(exportUrl).toContain("/export");
+  });
+
+  it("includes supportsAllDrives=true on the metadata prefetch and the export URL for Google-native files", async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ mimeType: "application/vnd.google-apps.document" }))
+      .mockResolvedValueOnce(new Response(new Uint8Array([37, 80, 68, 70]), { status: 200, headers: { "Content-Type": "application/pdf" } }));
+
+    await get("/gdrive/files/doc-id/content", env);
+
+    const [metadataUrl] = globalThis.fetch.mock.calls[0];
+    expect(new URL(metadataUrl).searchParams.get("supportsAllDrives")).toBe("true");
+    const [exportUrl] = globalThis.fetch.mock.calls[1];
+    expect(new URL(exportUrl).searchParams.get("supportsAllDrives")).toBe("true");
+  });
+
+  it("includes supportsAllDrives=true on the metadata prefetch and the alt=media download URL", async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ mimeType: "image/png" }))
+      .mockResolvedValueOnce(new Response(new Uint8Array([137, 80, 78, 71]), { status: 200, headers: { "Content-Type": "image/png" } }));
+
+    await get("/gdrive/files/img-id/content", env);
+
+    const [metadataUrl] = globalThis.fetch.mock.calls[0];
+    expect(new URL(metadataUrl).searchParams.get("supportsAllDrives")).toBe("true");
+    const [downloadUrl] = globalThis.fetch.mock.calls[1];
+    expect(new URL(downloadUrl).searchParams.get("supportsAllDrives")).toBe("true");
   });
 
   it("downloads binary files using alt=media", async () => {


### PR DESCRIPTION
## Bug 2 — Drive proxy omits shared-drive params

The Google Drive proxy (`src/api/routes/google.js`) never set `supportsAllDrives=true` on any Drive v3 get/export/download call, nor the shared-drive corpora params on list. Files living in a **shared drive** therefore 404 even with a valid delegated token whose impersonated user is a member of that drive.

### Changes
- `GET /gdrive/files` (list): `supportsAllDrives=true`, `includeItemsFromAllDrives=true`, `corpora=allDrives`
- `GET /gdrive/files/:fileId` (metadata): `supportsAllDrives=true`
- `GET /gdrive/files/:fileId/content`: `supportsAllDrives=true` on the metadata pre-fetch, the Google-native export URL, and the `alt=media` download URL

The content route fetches metadata **first**, so the metadata 404 is what broke the entire download flow.

### Verification (ground truth)
File `1pfPB3gq_l2LUWW29k3hadCi0q5F507-i` — a 1.84 MB PDF in the "Arias V Bianchi" shared drive (`driveId 0AHH7mqSeNtbbUk9PVA`). Fetched directly against the Drive v3 API with a delegated service-account token (`sub=nick@jeanarlene.com`, scope `drive`), mirroring the prod rotation path exactly:

| Call | Result |
|------|--------|
| `files.get?fields=mimeType` (no param) | **404 File not found** |
| `files.get?fields=mimeType&supportsAllDrives=true` | **200** |
| `files.get?alt=media&supportsAllDrives=true` (content) | **200 + 1,844,037 bytes** |
| `files.list` with shared-drive corpora params | **200** (lists shared-drive contents) |

GAM fetches the same file as ground truth, confirming the delegated subject is a member of the shared drive.

### Deploy gate
**Do NOT auto-merge.** Operator approves prod deploys of new code. This PR is the code half of the shared-drive fix; the credential half (Bug 1, augmented SA JSON in `CREDENTIAL_CACHE` KV) has already been provisioned out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing and listing files from Google shared drives across file retrieval and download operations.

* **Tests**
  * Enhanced test coverage to verify shared-drive functionality works correctly for file listing, metadata retrieval, and content downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->