### PR TITLE
chore(openapi): drop phantom connect-staging.chitty.cc server entry

### DIFF
--- a/public/openapi-optimized.json
+++ b/public/openapi-optimized.json
@@ -26,10 +26,6 @@
     {
       "url": "https://connect.chitty.cc",
       "description": "Production - ChittyConnect API Gateway"
-    },
-    {
-      "url": "https://connect-staging.chitty.cc",
-      "description": "Staging - Test environment"
     }
   ],
   "security": [

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -13,10 +13,6 @@
     {
       "url": "https://connect.chitty.cc",
       "description": "Production ChittyConnect API"
-    },
-    {
-      "url": "https://connect-staging.chitty.cc",
-      "description": "Staging environment"
     }
   ],
   "security": [


### PR DESCRIPTION
## What
Removes the `https://connect-staging.chitty.cc` entry from the `servers[]` list in both served OpenAPI specs (`public/openapi.json`, `public/openapi-optimized.json`).

## Why
`connect-staging.chitty.cc` **does not resolve** (DNS NXDOMAIN) — the custom domain was never provisioned, so the spec served at `connect.chitty.cc/openapi.json` advertises a dead staging endpoint to Custom GPT Action clients. The real staging worker is `chittyconnect-staging` at `*.chittyos.workers.dev` (per wrangler.jsonc); the public GPT-actions spec should list production only.

## Scope
Served specs only. Left out of scope: cosmetic curl examples in ~20 `*.md` docs (no functional impact), and `chittyos-workspace`'s `deploy-chittyconnect.yml` staging env (separate repo — flagged to the chittycommand session that found this).

## Validation
Both files re-parse as valid JSON; 0 `connect-staging` references remain in the served specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)