### PR TITLE
fix(deploy): recognise ai_search_namespaces + browser bindings in the extractor (salvaged from #265)

### DIFF
--- a/scripts/lib/extract-declared-bindings.mjs
+++ b/scripts/lib/extract-declared-bindings.mjs
@@ -67,18 +67,35 @@ const json = JSON.parse(stripJsonc(raw));
 function namesFrom(obj) {
   if (!obj || typeof obj !== 'object') return [];
   const out = [];
+  // Secret stores
   for (const item of obj.secrets_store_secrets || []) if (item?.binding) out.push(item.binding);
+  // KV namespaces
   for (const item of obj.kv_namespaces        || []) if (item?.binding) out.push(item.binding);
+  // D1 databases
   for (const item of obj.d1_databases         || []) if (item?.binding) out.push(item.binding);
+  // R2 buckets
   for (const item of obj.r2_buckets           || []) if (item?.binding) out.push(item.binding);
+  // Vectorize indexes (https://developers.cloudflare.com/vectorize/reference/client-api/)
   for (const item of obj.vectorize            || []) if (item?.binding) out.push(item.binding);
+  // Service bindings (https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/)
   for (const item of obj.services             || []) if (item?.binding) out.push(item.binding);
+  // Hyperdrive
   for (const item of obj.hyperdrive           || []) if (item?.binding) out.push(item.binding);
+  // Analytics Engine
   for (const item of obj.analytics_engine_datasets || []) if (item?.binding) out.push(item.binding);
+  // AI Search namespace bindings (https://developers.cloudflare.com/ai-search/api/migration/workers-binding/)
+  // Changelog: https://developers.cloudflare.com/changelog/post/2026-04-16-ai-search-namespace-binding/
+  for (const item of obj.ai_search_namespaces || []) if (item?.binding) out.push(item.binding);
+  // Browser rendering
+  if (obj.browser?.binding) out.push(obj.browser.binding);
+  // Workers AI
   if (obj.ai?.binding) out.push(obj.ai.binding);
+  // Queue producers
   if (obj.queues?.producers) for (const p of obj.queues.producers) if (p?.binding) out.push(p.binding);
   // queues.consumers are invocation handlers, NOT bindings — do not include.
+  // Durable Objects
   if (obj.durable_objects?.bindings) for (const d of obj.durable_objects.bindings) if (d?.name) out.push(d.name);
+  // Plain vars
   if (obj.vars && typeof obj.vars === 'object') for (const k of Object.keys(obj.vars)) out.push(k);
   return out;
 }


### PR DESCRIPTION
Salvaged remnant of #265, which is being closed. This is the one piece of that PR that survived review.

## What this is

`scripts/lib/extract-declared-bindings.mjs` gains handling for `ai_search_namespaces` and `browser` bindings, plus comments naming the CF docs for each binding type.

**Verified no-op today.** Ran main's extractor and this one in-tree against the current `wrangler.jsonc`:

```
main=73  pr=73
diff → clean, IDENTICAL
```

Same 73 declared production binding names, zero added, zero removed. It only changes behaviour once those binding types are actually declared — at which point the drift audit would otherwise silently miss them. Relevant because `eae77d2` on main currently has `ai_search_namespaces` disabled to work around a restricted-token error; when that is re-enabled, the audit needs to see it.

## Why the rest of #265 was dropped

Both of its substantive commits rested on premises the Cloudflare build logs falsify:

| commit | premise | reality |
|---|---|---|
| `caa98c8` | legacy `/bindings` endpoint doesn't work for Workers Builds | it works — main's prod build logs `OK — 73 declared bindings all present (live worker has 114 total)` |
| `b8f7c52` | Workers Builds doesn't expose `CLOUDFLARE_API_TOKEN` | it does — main's script has an unconditional token check that `exit 66`s, and the audit ran and passed inside Builds |

Consequences of merging them as written:

- `b8f7c52` would make Workers Builds **skip the binding audit**, removing the in-path drift guard from the production deploy path — the guard added after real incidents (#218 closed, **#223 still open**, 2026-06-03).
- `caa98c8` switches the audit path base to `/workers/scripts/$DEPLOYED_NAME`, which contradicts this repo's own `wrangler.jsonc:24` `"legacy_env": false` — under service environments, `--env staging` targets service `chittyconnect` / environment `staging`, not a script named `chittyconnect-staging`.
- Its jq (`.result.versions | map(select(.percentage > 0))`) is unverified against a real `/deployments` response body. If the shape is `{result:{deployments:[{versions:[…]}]}}` it yields empty and **silently falls back to the very endpoint it was meant to replace** — a no-op that adds a warning line. In `audit-bindings.sh` the deployments curl ends `|| true`, which would hide exactly that.
- `b8f7c52`'s commit message also describes `.github/workflows/deploy.yml` changes ("remove wrangler-action deploy step … add 90s wait for Builds"). **There is no `deploy.yml` in this repo**, and the commit touches only `scripts/safe-deploy.sh`.

## Separately: #265's red check was never about #265

PR builds run `npm run deploy:staging`, which fails with `code: 10223 — This account cannot create new non-production service environments`. Workers Builds is `failure` on the head of every recent PR (8/8 checked, including #266). That is a dashboard misconfiguration, not a code defect, and it is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binding detection for AI search namespaces and browser bindings.
  * Ensured these bindings are recognized consistently alongside existing resource and configuration bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->