### PR TITLE
fix(deploy): migrate off deprecated Cloudflare service environments

### DIFF
--- a/scripts/safe-deploy.sh
+++ b/scripts/safe-deploy.sh
@@ -67,11 +67,19 @@ fi
 
 echo "[safe-deploy] env=$ENV worker=$DEPLOYED_NAME"
 
-# ── 1. Deploy with explicit --env ────────────────────────────────────────────
+# ── 1. Deploy with explicit --env and explicit --config ──────────────────────
 # CHITTYCONNECT_SAFE_DEPLOY=1 is required by wrangler.jsonc's build.command
 # guard (#219). Without it, wrangler aborts before writing any binding.
-echo "[safe-deploy] running: npx wrangler deploy --env $ENV"
-CHITTYCONNECT_SAFE_DEPLOY=1 npx wrangler deploy --env "$ENV"
+#
+# --config is REQUIRED, not cosmetic. Wrangler's config discovery prefers
+# `wrangler.json` over `wrangler.jsonc` and walks up parent directories. A
+# stray untracked `wrangler.json` at the repo root (it is gitignored, so it
+# never appears in CI) silently shadowed the tracked config: this script
+# audited wrangler.jsonc while deploying whatever wrangler happened to find.
+# Pinning --config makes the tracked, code-reviewed file authoritative for
+# every deploy path — repo root, git worktrees, and CI alike.
+echo "[safe-deploy] running: npx wrangler deploy --env $ENV --config $WRANGLER_CFG"
+CHITTYCONNECT_SAFE_DEPLOY=1 npx wrangler deploy --env "$ENV" --config "$WRANGLER_CFG"
 
 # ── 2. Audit declared vs attached bindings ───────────────────────────────────
 echo "[safe-deploy] auditing bindings on live worker $DEPLOYED_NAME ..."

--- a/scripts/safe-deploy.sh
+++ b/scripts/safe-deploy.sh
@@ -79,7 +79,47 @@ echo "[safe-deploy] env=$ENV worker=$DEPLOYED_NAME"
 # Pinning --config makes the tracked, code-reviewed file authoritative for
 # every deploy path — repo root, git worktrees, and CI alike.
 echo "[safe-deploy] running: npx wrangler deploy --env $ENV --config $WRANGLER_CFG"
-CHITTYCONNECT_SAFE_DEPLOY=1 npx wrangler deploy --env "$ENV" --config "$WRANGLER_CFG"
+DEPLOY_LOG="$(mktemp)"
+trap 'rm -f "$DEPLOY_LOG"' EXIT
+set +e
+CHITTYCONNECT_SAFE_DEPLOY=1 npx wrangler deploy --env "$ENV" --config "$WRANGLER_CFG" 2>&1 | tee "$DEPLOY_LOG"
+WRANGLER_RC="${PIPESTATUS[0]}"
+set -e
+
+# ── 1a. Detect a CI-side Worker name override ────────────────────────────────
+# Cloudflare Workers Builds IGNORES the name in wrangler.jsonc and forces the
+# name of the script its build trigger is bound to. It prints a warning and
+# then deploys anyway:
+#
+#   ▲ [WARNING] Failed to match Worker name. Your config file is using the
+#     Worker name "chittyconnect-staging", but the CI system expected
+#     "chittyconnect". Overriding using the CI provided Worker name.
+#
+# On 2026-07-25 that override put the *staging* var set onto the *production*
+# script, because both build triggers were bound to the same script id. Nothing
+# in this script noticed: the audit below checks the name we COMPUTED, not the
+# name wrangler actually shipped to. Fail loud so a clobber is diagnosed in the
+# build that caused it rather than discovered later in prod.
+if grep -q "Failed to match Worker name" "$DEPLOY_LOG"; then
+  echo "::error::safe-deploy: CI overrode the Worker name. This deploy may have written env.$ENV config onto a DIFFERENT worker than intended." >&2
+  echo "  Expected to deploy: $DEPLOYED_NAME" >&2
+  grep -m1 "but the CI system expected" "$DEPLOY_LOG" >&2 || true
+  echo "  Fix the Workers Builds trigger so it is bound to a script named '$DEPLOYED_NAME', then redeploy." >&2
+  echo "  If this ran against production, restore it before doing anything else." >&2
+  exit 72
+fi
+
+# Cross-check the name wrangler reported uploading against the one we intended.
+UPLOADED_NAME="$(sed -n 's/^Uploaded \([A-Za-z0-9_-]*\).*/\1/p' "$DEPLOY_LOG" | head -1)"
+if [ -n "$UPLOADED_NAME" ] && [ "$UPLOADED_NAME" != "$DEPLOYED_NAME" ]; then
+  echo "::error::safe-deploy: wrangler uploaded '$UPLOADED_NAME' but this script targeted '$DEPLOYED_NAME'" >&2
+  exit 72
+fi
+
+if [ "$WRANGLER_RC" -ne 0 ]; then
+  echo "::error::safe-deploy: wrangler deploy failed (exit $WRANGLER_RC)" >&2
+  exit "$WRANGLER_RC"
+fi
 
 # ── 2. Audit declared vs attached bindings ───────────────────────────────────
 echo "[safe-deploy] auditing bindings on live worker $DEPLOYED_NAME ..."
@@ -94,15 +134,22 @@ if [ -z "$DECLARED" ]; then
   exit 70
 fi
 
+# Audit the SCRIPT, not a service environment. The old path here was
+#   /workers/services/$WORKER_NAME/environments/$ENV/bindings
+# which only resolves for a grandfathered service environment — it 404s for any
+# real top-level worker (that 404 is what failed build fe9061f3). Now that
+# staging is its own script rather than a service environment, the script-scoped
+# settings endpoint is the only one that works for both envs.
 ATTACHED_JSON="$(
   curl -sf -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-    "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/services/$WORKER_NAME/environments/$ENV/bindings"
+    "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/scripts/$DEPLOYED_NAME/settings"
 )" || {
-  echo "::error::safe-deploy: failed to fetch live bindings from CF API" >&2
+  echo "::error::safe-deploy: failed to fetch live bindings for script '$DEPLOYED_NAME' from CF API" >&2
+  echo "  If this is the first deploy of a new worker, confirm the script exists and the token can read it." >&2
   exit 71
 }
 
-ATTACHED="$(echo "$ATTACHED_JSON" | jq -r '.result[].name // empty' | sort -u)"
+ATTACHED="$(echo "$ATTACHED_JSON" | jq -r '.result.bindings[].name // empty' | sort -u)"
 
 MISSING=""
 while IFS= read -r name; do

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,6 @@
 
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "chittyconnect",
-  "legacy_env": false,
   "main": "src/index.js",
   "compatibility_date": "2026-03-02",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
@@ -178,6 +177,11 @@
     // STAGING — `wrangler deploy --env staging`
     // ════════════════════════════════════════════════════════════════
     "staging": {
+      // Explicit worker name. Without service environments, staging is its own
+      // top-level Worker script — NOT a `staging` environment of `chittyconnect`.
+      // This is what unblocks deploys: the account cannot create new non-production
+      // service environments (API error 10223).
+      "name": "chittyconnect-staging",
       // Staging is reachable at https://chittyconnect-staging.chittyos.workers.dev
       // No `routes` block — production owns connect.chitty.cc/* (mcp.chitty.cc/*
       // is owned by the chittymcp worker). Closes #192.
@@ -300,6 +304,12 @@
     // PRODUCTION — `wrangler deploy --env production`
     // ════════════════════════════════════════════════════════════════
     "production": {
+      // CRITICAL — pins this env to the EXISTING production Worker script.
+      // Without service environments wrangler name-suffixes by default, so an
+      // unnamed env.production would target a NEW worker `chittyconnect-production`
+      // and strand the live script plus its connect.chitty.cc/* route.
+      // This name MUST stay identical to the top-level "name".
+      "name": "chittyconnect",
       // workers.dev URL is enabled so post-deploy CI can probe /health without
       // hitting the zone WAF (which 403's GitHub Actions runner IPs). The
       // public surface is connect.chitty.cc. mcp.chitty.cc is owned by the


### PR DESCRIPTION
## Problem

`wrangler.jsonc` set `"legacy_env": false`, putting chittyconnect in Cloudflare's **deprecated service-environments** model. Every build logged:

> `Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION.`

Consequences:
- **Production** deploys worked only because the `production` service environment was already grandfathered in.
- **Staging** deploys failed outright: `code 10223 — This account cannot create new non-production service environments`. This is the source of the perpetually-red `deploy:staging` PR check. `env.staging` was fully declared; the account-level capability was the blocker.

chittyconnect and chittysecrets were the only two repos across CHITTYOS/ and CHITTYFOUNDATION/ still setting `legacy_env: false`.

## Changes

```
remove  "legacy_env": false
add     env.production.name = "chittyconnect"          // pins to the EXISTING script
add     env.staging.name    = "chittyconnect-staging"  // new top-level worker, no 10223
```

**The production name pin is load-bearing.** `env.production` had no `name` key of its own, so it inherited. Without service environments wrangler name-suffixes by default — an unnamed `env.production` would have targeted a brand-new `chittyconnect-production` worker and **stranded the live script along with its `connect.chitty.cc/*` route**. That failure mode has already caused three prod binding-wipe incidents (#219, #207, and twice on 2026-06-03; #218 closed, #223 open).

Verified the trap is real rather than theoretical: `env.dev`, which still has no `name` key, now resolves to `chittyconnect-dev`.

Follows the org's existing pattern — `chittyentity/workers/chittyagent-imessage/wrangler.jsonc` (top-level `name` + `env.production.name` pinned to the same value).

## Also: a shadow config was silently overriding the tracked one

`scripts/safe-deploy.sh` ran `wrangler deploy --env "$ENV"` with **no `--config`**. Wrangler's config discovery prefers `wrangler.json` over `wrangler.jsonc` and walks up parent directories — and an untracked `wrangler.json` (gitignored at `.gitignore:59`, so **invisible in CI**) sat at the repo root shadowing the tracked file. The script was auditing `wrangler.jsonc` while deploying whatever wrangler happened to find.

Both files happened to resolve to byte-identical production bindings, so nothing was broken — but it was un-reviewable drift waiting to happen, and it would have made this migration silently inert for local deploys. `--config "$WRANGLER_CFG"` now pins the reviewed file on every deploy path; the stray file has been removed (backed up off-repo).

## Live verification — no route handoff

Confirmed against the live Cloudflare API (read-only) that the base script and the `production` service environment are the **same underlying Worker object**, so this migration is a no-op on worker identity:

| Path | etag |
|---|---|
| `/workers/scripts` (base script) | `e66e8221e9712ac7d1473ccd1da42532…` |
| `/workers/services/chittyconnect` → `default_environment.script.etag` | `e66e8221e9712ac7d1473ccd1da42532…` |

Corroborated by identical `script_tag` (`19a1d50542d84acb99cd2c1ee8142c7f`) and byte-identical binding sets (114 live bindings) via both paths.

Decisive datapoint — route ownership:
```json
{"pattern":"connect.chitty.cc/*","script":"chittyconnect"}
```
The route is owned by the **unsuffixed** base script. Also confirmed: `chittyconnect-production` does **not** exist (`10090`), `chittyconnect-staging` does **not** yet exist, and `chittyconnect` has exactly one service environment (`production`) — consistent with the 10223 error on staging.

**No route handoff, no cutover window, no orphaned script.**

## Config validation — no credentials, no deploy

- Wrangler's own resolver (`unstable_readConfig`):
  - `--env production` → `"chittyconnect"`, route `connect.chitty.cc/*`
  - `--env staging` → `"chittyconnect-staging"`, no routes
- `wrangler deploy --env production --dry-run` → **73 bindings, byte-identical to the pre-migration baseline** (diff empty)
- `--env staging --dry-run` → 73, identical to baseline
- `scripts/lib/extract-declared-bindings.mjs production` independently agrees at **73**
- Deprecation warning gone
- **496 tests pass**, 1 pre-existing skip
- `bash -n scripts/safe-deploy.sh` clean

## Rollback plan for `connect.chitty.cc/*`

Because the name is pinned to the existing script, the route never changes hands. If a prod deploy still needs reverting:

- **Rollback target:** deployment `808c1147-a377-4107-a5c0-ec4d76d3439f` / version `ac53e49e-63fc-4f78-aa35-2316e42eac46` (**#946**, `2026-07-24T23:32:35Z`)
- Current at time of writing: version `0384daab-f6a6-4f70-a22d-ded03e9f05e7` (**#947**, `2026-07-25T02:15:33Z`) — the Workers Build for #268
- `npx wrangler rollback --name chittyconnect`, or revert this commit and re-run `npm run deploy:production`
- Route-level fallback: re-point route `10bad0c1831d44f29906383ea3c1c8d8` on zone `7a4f759e0928fb2be4772a2f72ad0df2` to `script: chittyconnect`

## Expected effect on CI

The `deploy:staging` check should go **green for the first time** — staging becomes a top-level worker (`chittyconnect-staging`, workers_dev only, no routes) instead of an impossible service environment. That staging deploy is the first real end-to-end proof of the migration and it cannot touch production.

Refs #219, #207, #218, #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer deployment validation, including explicit environment and configuration requirements.
  * Added checks to confirm deployments target the intended worker and that live bindings match configuration.
  * Configured staging and production deployments to use dedicated, explicitly named worker scripts.

* **Bug Fixes**
  * Improved detection of deployment warnings and binding drift, preventing potentially incorrect releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->