### PR TITLE
fix(deploy): drop legacy_env, pin env.production to base script name

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,6 @@
 
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "chittyconnect",
-  "legacy_env": false,
   "main": "src/index.js",
   "compatibility_date": "2026-03-02",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
@@ -300,6 +299,11 @@
     // PRODUCTION — `wrangler deploy --env production`
     // ════════════════════════════════════════════════════════════════
     "production": {
+      // Deploy to the base script name, not the default `chittyconnect-production`.
+      // Required: this env owns connect.chitty.cc, the 41 script-level secrets, and
+      // the McpConnectAgent / SessionStateActor DO namespaces — all of which bind by
+      // script name. Without this override the worker would be renamed and orphaned.
+      "name": "chittyconnect",
       // workers.dev URL is enabled so post-deploy CI can probe /health without
       // hitting the zone WAF (which 403's GitHub Actions runner IPs). The
       // public surface is connect.chitty.cc. mcp.chitty.cc is owned by the


### PR DESCRIPTION
## Why staging deploys fail

`wrangler.jsonc` set `"legacy_env": false`, which opts wrangler out of the modern one-worker-per-env model and into **deprecated service environments**. That is why the failure surfaces on the legacy API path `/workers/services/chittyconnect/environments/staging`, and why Cloudflare rejects it:

```
✘ [ERROR] A request to the Cloudflare API
  (/accounts/0bc21e3a.../workers/services/chittyconnect/environments/staging) failed.
  This account cannot create new non-production service environments. [code: 10223]
```

Cloudflare no longer permits creating new non-production service environments **on any plan**. Production predates the cutoff so it still deploys; `staging` was never created and now never can be. Every push to a non-production branch has been red since.

> This is not a plan limitation. Upgrading the Workers plan would not fix it. The `Service environments are deprecated` warning wrangler already prints on every run *was* the cause.

## Origin

`0dcf9ba` — *"chore: configure legacy_env=false and fix staging bindings"*.

The flag was inert for that commit's stated purpose. `legacy_env` controls **naming semantics only** and never affects binding inheritance — env blocks must redeclare bindings under either setting. The binding redeclarations in that same commit are what actually fixed staging bindings.

The repo already assumed the default (`legacy_env: true`) in two places that contradicted the flag:

| Location | Assumes |
|---|---|
| `scripts/safe-deploy.sh` | `DEPLOYED_NAME="${WORKER_NAME}-staging"` → `chittyconnect-staging` |
| `wrangler.jsonc` staging comment | *"reachable at chittyconnect-staging.chittyos.workers.dev"* |

The flag was the outlier.

## The trap this PR avoids

Removing `legacy_env: false` **alone** would have caused a production outage. `env.production` had no `name` override, so `--env production` would deploy to a brand-new `chittyconnect-production` worker and orphan the live `chittyconnect` script that owns `connect.chitty.cc`.

Pinning `"name": "chittyconnect"` in `env.production` keeps production script identity unchanged. This is the same pattern `chittyentity/workers/chittyagent-npm` already uses (`env.production.name: "chittyagent-npm"`), whose builds are green.

## Verification (read-only, against live Cloudflare state, before this change)

- **Script identity — same object.** The `chittyconnect` production service environment and the plain `chittyconnect` script share `script_tag 19a1d50542d84acb99cd2c1ee8142c7f`, identical `etag` and timestamps. Cloudflare persists a service's default/production environment *as* the base script.
- **No `chittyconnect-production` and no `chittyconnect-staging` script exist.** The service object registers only a `production` environment — staging has never deployed, consistent with 10223.
- **Route ownership.** `connect.chitty.cc/*` → script `chittyconnect` (unsuffixed). `GET /health` → `200 {"status":"ok","service":"chittyconnect","version":"2.2.0"}`.
- **Secrets survive.** 41 script-level `secret_text` values attach to the script, not to wrangler.jsonc, and the script name is unchanged.
- **Durable Objects survive** — the real blast radius. `McpConnectAgent` (`28f55bc4…`) and `SessionStateActor` (`a2d48315…`), migration tag `v5`, bind by script name. Unchanged name ⇒ session state and MCP storage preserved.
- **Blast radius is one repo.** `chittyconnect` is the only `legacy_env: false` across all of CHITTYOS and CHITTYFOUNDATION.

**Causal before/after** via `wrangler deploy --dry-run` on this exact diff:

| Config | `--env staging` |
|---|---|
| current `main` | `▲ WARNING … Service environments are deprecated, and will be removed in the future. DO NOT USE IN PRODUCTION.` |
| this PR | *(no warning)* |

## Result

- `--env production` → `chittyconnect` (**unchanged** — same script, routes, secrets, DOs)
- `--env staging` → `chittyconnect-staging` as its own worker, which `safe-deploy.sh` has always expected

## Merge note

Merging triggers a Workers Builds **production** deploy. Recommend watching it rather than auto-merging: immediately after deploy, re-check `GET /workers/services/chittyconnect` for `script_tag` continuity (`19a1d505…`) and curl `connect.chitty.cc/health`. Auto-merge deliberately **not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)