### PR TITLE
fix(credentials): fail closed on plaintext credential-reveal routes

### DIFF
--- a/src/api/middleware/require-scope.js
+++ b/src/api/middleware/require-scope.js
@@ -1,0 +1,141 @@
+/**
+ * Scope Enforcement Middleware
+ *
+ * Authorization layer for routes that return credential material. The
+ * `authenticate` middleware (./auth.js) establishes *identity* — that a caller
+ * presented a key which exists and is active. It deliberately makes no
+ * authorization decision. This middleware makes that decision, keyed off the
+ * `scopes` array already written onto every issued key record by
+ * `generateAPIKey` (src/middleware/mcp-auth.js).
+ *
+ * Deny-by-default: a key with no `scopes` field, an empty `scopes` array, or a
+ * `scopes` array lacking the required entry is rejected. There is no
+ * allow-with-warning mode — per the sensitive-intent contract
+ * (~/.ch1tty/canon/system-wide-sensitive-intent-contract-v1.md) the credential
+ * path fails closed, and a warning nobody reads is an open door.
+ *
+ * The 403 body names the scope that was required so an under-provisioned
+ * caller can be reissued a correct key without needing to read this source.
+ *
+ * Scope vocabulary is namespaced separately from the MCP OAuth vocabulary
+ * (`mcp:read|write|admin`, declared in src/middleware/oauth-provider.js). Both
+ * land in the same `keyInfo.scopes` array, and a key granted MCP tool access
+ * must never satisfy a credential-reveal check by vocabulary coincidence.
+ *
+ * @module api/middleware/require-scope
+ */
+
+/**
+ * Vaults the credential routes expose. Kept in sync with the `validVaults`
+ * check in ../routes/credentials.js — a vault absent here has no reachable
+ * scope and is therefore denied, which is the correct direction to fail.
+ */
+export const REVEAL_SCOPE_PREFIX = "credentials:reveal";
+
+/**
+ * Build the scope string that guards reveal of a given vault.
+ *
+ * @param {string} vault - Vault name (infrastructure | services | integrations)
+ * @returns {string} e.g. "credentials:reveal:infrastructure"
+ */
+export function revealScopeFor(vault) {
+  return `${REVEAL_SCOPE_PREFIX}:${vault}`;
+}
+
+/**
+ * Read the scopes off the authenticated key, tolerating legacy records.
+ *
+ * Legacy keys predating the `scopes` field surface as `undefined`; keys issued
+ * without explicit scopes surface as `[]`. Both mean "no grants" and collapse
+ * to the same denial — there is no meaningful distinction to preserve.
+ *
+ * @param {object} c - Hono context
+ * @returns {string[]}
+ */
+function scopesOf(c) {
+  const keyInfo = c.get("apiKey");
+  const scopes = keyInfo?.scopes;
+  return Array.isArray(scopes) ? scopes : [];
+}
+
+/**
+ * Require a fixed scope.
+ *
+ * @param {string} scope - Scope string the caller's key must carry
+ * @returns {Function} Hono middleware
+ */
+export function requireScope(scope) {
+  return async (c, next) => {
+    return enforce(c, next, scope);
+  };
+}
+
+/**
+ * Require a scope derived from the request — used where the guarded resource
+ * is identified by a path param (e.g. `:vault`) and a single fixed scope would
+ * be either too coarse or unknowable at mount time.
+ *
+ * If the resolver returns a falsy value the request is denied: an unresolvable
+ * scope means an unrecognised resource, and guessing would defeat the gate.
+ *
+ * @param {(c: object) => string|undefined} resolve - Derives the required scope
+ * @returns {Function} Hono middleware
+ */
+export function requireScopeFrom(resolve) {
+  return async (c, next) => {
+    const scope = resolve(c);
+    if (!scope) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "SCOPE_UNRESOLVABLE",
+            message:
+              "Could not determine the scope required for this resource; denying.",
+          },
+        },
+        403,
+      );
+    }
+    return enforce(c, next, scope);
+  };
+}
+
+/**
+ * Shared decision + audit point for both middleware forms.
+ *
+ * The audit line carries the key's service/name and the scope decision but
+ * never the key itself or any credential material.
+ */
+async function enforce(c, next, scope) {
+  const keyInfo = c.get("apiKey") || {};
+  const granted = scopesOf(c);
+  const allowed = granted.includes(scope);
+
+  console.log(
+    JSON.stringify({
+      tag: "scope-audit",
+      scope,
+      allowed,
+      keyType: keyInfo.type || "api-key",
+      service: keyInfo.service || keyInfo.name || "unknown",
+      path: c.req.path,
+    }),
+  );
+
+  if (!allowed) {
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: "INSUFFICIENT_SCOPE",
+          message: `This endpoint requires the '${scope}' scope. The presented key does not carry it.`,
+          required: scope,
+        },
+      },
+      403,
+    );
+  }
+
+  await next();
+}

--- a/src/api/routes/credentials.js
+++ b/src/api/routes/credentials.js
@@ -11,8 +11,20 @@
 import { Hono } from "hono";
 import { EnhancedCredentialProvisioner } from "../../services/credential-provisioner-enhanced.js";
 import { createCredentialBroker } from "../../lib/credential-broker.js";
+import {
+  requireScope,
+  requireScopeFrom,
+  revealScopeFor,
+} from "../middleware/require-scope.js";
 
 const credentialsRoutes = new Hono();
+
+/**
+ * Vaults reachable through the reveal route. Also the source of the scope
+ * vocabulary — the reveal guard derives `credentials:reveal:<vault>` from this
+ * same list, so an unlisted vault has no grantable scope and is denied.
+ */
+const VALID_VAULTS = ["infrastructure", "services", "integrations"];
 
 /**
  * POST /api/credentials/provision
@@ -464,7 +476,12 @@ credentialsRoutes.delete("/revoke", async (c) => {
  *   "phoneNumber": "+1..."
  * }
  */
-credentialsRoutes.get("/twilio", async (c) => {
+// Returns live Twilio credentials in the response body — gated on the
+// integrations reveal scope. Deny-by-default; see middleware/require-scope.js.
+credentialsRoutes.get(
+  "/twilio",
+  requireScope(revealScopeFor("integrations")),
+  async (c) => {
   try {
     const serviceName =
       c.req.header("X-Service-Name") || c.get("apiKey")?.service || "unknown";
@@ -542,8 +559,9 @@ credentialsRoutes.get("/twilio", async (c) => {
       },
       500,
     );
-  }
-});
+    }
+  },
+);
 
 /**
  * GET /api/credentials/:vault/:item/:field
@@ -570,14 +588,23 @@ credentialsRoutes.get("/twilio", async (c) => {
  *   }
  * }
  */
-credentialsRoutes.get("/:vault/:item/:field", async (c) => {
+// Returns broker-resolved credential material in the response body — gated on
+// the per-vault reveal scope. The guard runs ahead of the handler's own vault
+// validation and denies an unrecognised vault rather than guessing a scope.
+credentialsRoutes.get(
+  "/:vault/:item/:field",
+  requireScopeFrom((c) => {
+    const vault = c.req.param("vault");
+    return VALID_VAULTS.includes(vault) ? revealScopeFor(vault) : undefined;
+  }),
+  async (c) => {
   try {
     const vault = c.req.param("vault");
     const item = c.req.param("item");
     const field = c.req.param("field");
 
     // Validate vault name
-    const validVaults = ["infrastructure", "services", "integrations"];
+    const validVaults = VALID_VAULTS;
     if (!validVaults.includes(vault)) {
       return c.json(
         {
@@ -667,8 +694,9 @@ credentialsRoutes.get("/:vault/:item/:field", async (c) => {
       },
       status,
     );
-  }
-});
+    }
+  },
+);
 
 /**
  * PUT /api/credentials/:vault/:item/:field

--- a/tests/api/require-scope.test.js
+++ b/tests/api/require-scope.test.js
@@ -1,0 +1,242 @@
+/**
+ * Scope enforcement middleware — behavioural tests.
+ *
+ * These mount the real middleware on a real Hono app and dispatch real
+ * Requests through it, asserting on real Responses. Nothing is mocked: the
+ * middleware's only input is the `apiKey` context value that `authenticate`
+ * sets, so a preceding middleware that sets it exactly as `authenticate` does
+ * is the genuine article, not a stand-in.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import {
+  requireScope,
+  requireScopeFrom,
+  revealScopeFor,
+  REVEAL_SCOPE_PREFIX,
+} from "../../src/api/middleware/require-scope.js";
+
+const VALID_VAULTS = ["infrastructure", "services", "integrations"];
+
+/**
+ * Build an app whose first middleware seeds `apiKey` the same way
+ * `authenticate` does, then guards a route that would return credential
+ * material. `keyInfo` of `null` models a route reached with no key set.
+ */
+function appWithKey(keyInfo, guard) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (keyInfo !== null) c.set("apiKey", keyInfo);
+    await next();
+  });
+  app.get("/:vault/:item/:field", guard, (c) =>
+    c.json({ success: true, value: "REVEALED" }),
+  );
+  app.get("/twilio-style", guard, (c) =>
+    c.json({ success: true, value: "REVEALED" }),
+  );
+  return app;
+}
+
+const vaultGuard = requireScopeFrom((c) => {
+  const vault = c.req.param("vault");
+  return VALID_VAULTS.includes(vault) ? revealScopeFor(vault) : undefined;
+});
+
+describe("revealScopeFor", () => {
+  it("namespaces scopes under the reveal prefix", () => {
+    expect(revealScopeFor("infrastructure")).toBe(
+      "credentials:reveal:infrastructure",
+    );
+    expect(REVEAL_SCOPE_PREFIX).toBe("credentials:reveal");
+  });
+});
+
+describe("requireScopeFrom — vault-derived reveal guard", () => {
+  it("allows a key carrying the matching per-vault scope", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: ["credentials:reveal:infrastructure"] },
+      vaultGuard,
+    );
+
+    const res = await app.request("/infrastructure/neon/connection_url");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, value: "REVEALED" });
+  });
+
+  it("denies a key whose scope is for a different vault", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: ["credentials:reveal:integrations"] },
+      vaultGuard,
+    );
+
+    const res = await app.request("/infrastructure/neon/connection_url");
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("INSUFFICIENT_SCOPE");
+    // The 403 must name the scope so an under-provisioned caller can be
+    // reissued without reading the source.
+    expect(body.error.required).toBe("credentials:reveal:infrastructure");
+    expect(JSON.stringify(body)).not.toContain("REVEALED");
+  });
+
+  it("denies a legacy key record with no scopes field at all", async () => {
+    const app = appWithKey({ status: "active" }, vaultGuard);
+
+    const res = await app.request("/services/chittyid/service_token");
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("INSUFFICIENT_SCOPE");
+  });
+
+  it("denies a key with an empty scopes array", async () => {
+    const app = appWithKey({ status: "active", scopes: [] }, vaultGuard);
+
+    const res = await app.request("/services/chittyid/service_token");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("denies a key whose scopes field is not an array", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: "credentials:reveal:services" },
+      vaultGuard,
+    );
+
+    const res = await app.request("/services/chittyid/service_token");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("does not let an MCP scope satisfy a credential-reveal check", async () => {
+    // mcp:admin is the broadest scope in the MCP OAuth vocabulary. It must not
+    // grant credential reveal by vocabulary coincidence.
+    const app = appWithKey(
+      { status: "active", scopes: ["mcp:read", "mcp:write", "mcp:admin"] },
+      vaultGuard,
+    );
+
+    const res = await app.request("/infrastructure/neon/connection_url");
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.required).toBe(
+      "credentials:reveal:infrastructure",
+    );
+  });
+
+  it("denies an unrecognised vault rather than guessing a scope", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: ["credentials:reveal:infrastructure"] },
+      vaultGuard,
+    );
+
+    const res = await app.request("/etc-passwd/root/shadow");
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("SCOPE_UNRESOLVABLE");
+  });
+
+  it("denies when no key was set on the context", async () => {
+    const app = appWithKey(null, vaultGuard);
+
+    const res = await app.request("/infrastructure/neon/connection_url");
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("credentials routes — real wiring", () => {
+  /**
+   * Mounts the actual route module behind a shim that seeds `apiKey` exactly
+   * as `authenticate` does. No env bindings are supplied on purpose: the
+   * handlers need a credential broker and a DB, so if any of these requests
+   * reached a handler it would throw rather than 403. A clean 403 is therefore
+   * positive evidence the guard short-circuits ahead of the handler.
+   */
+  async function mountReal(keyInfo) {
+    // Named export, mounted the same way src/api/router.js:178 mounts it.
+    const { credentialsRoutes } = await import(
+      "../../src/api/routes/credentials.js"
+    );
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("apiKey", keyInfo);
+      await next();
+    });
+    app.route("/api/credentials", credentialsRoutes);
+    return app;
+  }
+
+  const unscoped = [
+    ["legacy record with no scopes field", { status: "active" }],
+    ["mcp:admin only", { status: "active", scopes: ["mcp:admin"] }],
+    [
+      "reveal scope for a different vault",
+      { status: "active", scopes: ["credentials:reveal:services"] },
+    ],
+  ];
+
+  it.each(unscoped)(
+    "GET /:vault/:item/:field is gated against %s",
+    async (_label, keyInfo) => {
+      const app = await mountReal(keyInfo);
+
+      const res = await app.request(
+        "/api/credentials/infrastructure/neon/connection_url",
+      );
+      const body = await res.text();
+
+      expect(res.status).toBe(403);
+      expect(body).toContain("INSUFFICIENT_SCOPE");
+      expect(body).toContain("credentials:reveal:infrastructure");
+    },
+  );
+
+  it.each([
+    ["legacy record with no scopes field", { status: "active" }],
+    ["mcp:admin only", { status: "active", scopes: ["mcp:admin"] }],
+  ])("GET /twilio is gated against %s", async (_label, keyInfo) => {
+    const app = await mountReal(keyInfo);
+
+    const res = await app.request("/api/credentials/twilio");
+    const body = await res.text();
+
+    expect(res.status).toBe(403);
+    expect(body).toContain("credentials:reveal:integrations");
+    // The Twilio payload field names must not appear in a denial.
+    expect(body).not.toContain("accountSid");
+    expect(body).not.toContain("authToken");
+  });
+});
+
+describe("requireScope — fixed-scope guard (twilio route shape)", () => {
+  const guard = requireScope(revealScopeFor("integrations"));
+
+  it("allows a key carrying the integrations reveal scope", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: ["credentials:reveal:integrations"] },
+      guard,
+    );
+
+    const res = await app.request("/twilio-style");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("denies a key without it and never leaks the payload", async () => {
+    const app = appWithKey(
+      { status: "active", scopes: ["credentials:reveal:services"] },
+      guard,
+    );
+
+    const res = await app.request("/twilio-style");
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.required).toBe("credentials:reveal:integrations");
+    expect(JSON.stringify(body)).not.toContain("REVEALED");
+  });
+});


### PR DESCRIPTION
## What

`GET /api/credentials/:vault/:item/:field` ([credentials.js:573](../blob/main/src/api/routes/credentials.js#L573)) and `GET /api/credentials/twilio` ([:467](../blob/main/src/api/routes/credentials.js#L467)) return broker-resolved secrets as **plaintext** in the response body. The only authorization gate was `keyInfo.status === "active"` at [auth.js:142](../blob/main/src/api/middleware/auth.js#L142) — grep for `scope` across both files finds zero authorization checks. **Any active API key could reveal any credential** across the `infrastructure`, `services`, and `integrations` vaults.

This adds `src/api/middleware/require-scope.js` and applies it to both routes, deny-by-default.

## Design decisions

- **Deny-by-default, no observe mode.** Missing / empty / non-array `scopes` all reject. The sensitive-intent contract requires the credential path to fail closed; a log-only phase means the hole stays fully open for the window and tends not to get flipped.
- **Per-vault scopes** — `credentials:reveal:{infrastructure,services,integrations}`, derived from the same vault list the handler validates against. An unrecognised vault yields no scope and is denied rather than guessed at.
- **Namespaced apart from `mcp:read|write|admin`.** Both vocabularies land in the same `keyInfo.scopes` array; `mcp:admin` must not satisfy a credential-reveal check by coincidence. There's an explicit test for this.
- **Self-describing 403** — the body carries `required: "<scope>"` so an under-provisioned caller can be reissued without reading source.

## Scope-gating is harm reduction, not the cure

A *scoped* plaintext reveal is still a plaintext long-lived secret in a response body. No in-repo consumer of either route exists — server-side callers (`github-actions.js:172`, `credential-provisioner-enhanced.js:27`, `credential-helper.js:18`) use `createCredentialBroker(env)` in-process and are unaffected. **Intended follow-up is deleting both routes** once 403 telemetry confirms no external caller. Filed separately so gating doesn't quietly become the destination.

## Validation

- `npx vitest run` → **512 passed**, 1 skipped, 0 failed
- `npx eslint` on all three changed files → clean
- Tests mount the **real** route module with **no env bindings**. The handlers need a credential broker and a DB, so a clean 403 is positive evidence the guard short-circuits ahead of the handler — not just that the middleware works in isolation.
- No `vi.mock()` on any DB or service module; real Hono app, real Requests, real Responses.

## Not in this PR (audited, filed separately)

| Finding | Location | Status |
|---|---|---|
| `API_KEYS.put()` sets no `expirationTtl` — keys never expire, KV as authz source of truth | `src/middleware/mcp-auth.js:173,203` | open, compounds this one |
| Broker short-circuited by raw `env[X]` truthiness on Secrets-Store bindings; `resolveBinding()` at `thirdparty.js:890` already solves it and isn't used | `src/lib/credential-helper.js:68-81,101-121`, `src/intelligence/context-resolver.js:530-532` | code-verified, runtime status unverified |
| `failoverToEnvironment` reads arbitrary env vars on broker failure — dead under current config, but `CREDENTIAL_FAILOVER_ENABLED="true"` in all 3 envs | `src/services/chittysecrets-connect-client.js:246-249` | latent |
| MCP credential tools 404 (`POST /api/credentials/retrieve`, `/audit` — no such routes) | `src/mcp/tool-registry.js:962,985` | drift |
| Plaintext reveal documented as intended behavior | `docs/SECRET_MANAGEMENT_ARCHITECTURE.md:81` | needs revision |
| Both governance audit docs dated 2026-03-25, pre-decommission, reference vars absent from live `wrangler.jsonc` | `docs/governance/` | stale |

**Refuted during audit, recorded so it isn't re-raised:** MCP OAuth tokens do *not* escalate via the `unwrapToken` branch at `auth.js:114`. `isOAuthProviderRoute()` ([index.js:2214](../blob/main/src/index.js#L2214)) covers only `/authorize`, `/token`, `/register` and two `.well-known` paths, so `/api/*` uses `app.fetch` with raw env where `OAUTH_PROVIDER` is undefined.

## Deploy note

Merging does not deploy via GitHub Actions — only `binding-drift-audit.yml` runs on push to main, and it's an audit. **I could not verify whether a Cloudflare Workers Build is configured to deploy this repo on push** (no CF API token in the authoring session). If one is, merging changes production auth behavior immediately. Confirm before merge.

Refs: operator decision 2026-07-25 (decision 5) — standalone remediation, deliberately not folded into the chittycan OAuth work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scope-based access controls for credential-reveal endpoints.
  * Added vault-specific permissions for credential access, including Twilio integrations.
  * Requests without the required permissions now receive clear 403 errors.

* **Bug Fixes**
  * Unrecognized vaults are denied safely before credential handlers run.
  * Unauthorized requests no longer expose credential payload details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->