### PR TITLE
fix(secrets): resolve Secrets Store bindings to values, not binding objects

### DIFF
--- a/src/services/cloudflare-secrets-client.js
+++ b/src/services/cloudflare-secrets-client.js
@@ -71,6 +71,43 @@ const PATH_TO_ENV = {
   "services/chittymint/service_token": "CHITTYAUTH_ISSUED_MINT_API_KEY",
 };
 
+/**
+ * Resolve one env entry to a secret STRING.
+ *
+ * Two binding shapes land on `env` and they are not interchangeable:
+ *
+ *   wrangler secret put  -> a plain string
+ *   secrets_store_secrets -> an object with an async .get()
+ *
+ * Every lookup below used to be `if (this.env[X]) return this.env[X]`. A
+ * Secrets Store binding is an object, and an object is truthy, so that
+ * returned the BINDING where callers expect the secret — silently, with no
+ * type error, producing "[object Object]" wherever the value got
+ * interpolated into a header or a connection string.
+ *
+ * The defect is dormant only because no consumer binds Secrets Store today
+ * (0 of 51 tracked wrangler configs in chittyentity). It fires on the first
+ * worker that adopts the documented policy — i.e. it punishes exactly the
+ * person doing the right thing, and would read as "Secrets Store is broken"
+ * rather than "the broker never supported it".
+ *
+ * Duck-typed rather than instanceof-checked because the binding class is not
+ * exported by the runtime. Same shape as
+ * chittyentity/packages/agent-cf/src/adapters/env-secret-provider.ts, which
+ * already got this right.
+ *
+ * @param {unknown} bound
+ * @returns {Promise<string|undefined>} the secret, or undefined if absent
+ */
+async function resolveBinding(bound) {
+  if (typeof bound === "string") return bound.length > 0 ? bound : undefined;
+  if (bound && typeof bound === "object" && typeof bound.get === "function") {
+    const value = await bound.get();
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+  }
+  return undefined;
+}
+
 export class CloudflareSecretsClient {
   constructor(env) {
     this.env = env;
@@ -85,35 +122,31 @@ export class CloudflareSecretsClient {
    * @returns {Promise<string>} Credential value
    */
   async get(credentialPath, options = {}) {
-    // Try mapped path first
+    // Each candidate is resolved through resolveBinding so a Secrets Store
+    // binding yields its VALUE rather than the binding object. Order is
+    // unchanged: mapped path, then literal name, then derived names.
+    const candidates = [];
+
     const envName = PATH_TO_ENV[credentialPath];
-    if (envName && this.env[envName]) {
-      return this.env[envName];
-    }
+    if (envName) candidates.push(envName);
 
-    // Try direct env var name (e.g., "NEON_DATABASE_URL")
-    if (this.env[credentialPath]) {
-      return this.env[credentialPath];
-    }
+    candidates.push(credentialPath);
 
-    // Try constructing env var from path components
     const parts = credentialPath.split("/");
     if (parts.length === 3) {
       const [, item, field] = parts;
-      // Try ITEM_FIELD pattern
-      const envGuess = `${item.toUpperCase()}_${field.toUpperCase()}`;
-      if (this.env[envGuess]) {
-        return this.env[envGuess];
-      }
-      // Try just FIELD
-      if (this.env[field.toUpperCase()]) {
-        return this.env[field.toUpperCase()];
-      }
+      candidates.push(`${item.toUpperCase()}_${field.toUpperCase()}`);
+      candidates.push(field.toUpperCase());
+    }
+
+    for (const name of candidates) {
+      const value = await resolveBinding(this.env[name]);
+      if (value !== undefined) return value;
     }
 
     throw new Error(
       `Credential not found in env bindings: ${credentialPath}. ` +
-      `Add mapping to PATH_TO_ENV or ensure secret is deployed via sync-secrets.sh`
+        `Add mapping to PATH_TO_ENV or ensure secret is deployed via sync-secrets.sh`,
     );
   }
 
@@ -153,14 +186,16 @@ export class CloudflareSecretsClient {
       "ENCRYPTION_KEY",
     ];
 
-    const present = required.filter(k => !!this.env[k]);
-    const missing = required.filter(k => !this.env[k]);
+    const present = required.filter((k) => !!this.env[k]);
+    const missing = required.filter((k) => !this.env[k]);
 
     return {
       status: missing.length === 0 ? "healthy" : "degraded",
       type: "cloudflare-secrets",
       bindings: {
-        total: Object.keys(this.env).filter(k => k === k.toUpperCase() && k.length > 3).length,
+        total: Object.keys(this.env).filter(
+          (k) => k === k.toUpperCase() && k.length > 3,
+        ).length,
         required: required.length,
         present: present.length,
         missing,

--- a/tests/services/cloudflare-secrets-client.test.js
+++ b/tests/services/cloudflare-secrets-client.test.js
@@ -1,0 +1,104 @@
+/**
+ * CloudflareSecretsClient — binding resolution.
+ *
+ * Regression cover for a dormant defect: every lookup in get() was
+ * `if (this.env[X]) return this.env[X]`. Two binding shapes land on `env`:
+ *
+ *   wrangler secret put   -> a plain string
+ *   secrets_store_secrets -> an object with an async .get()
+ *
+ * A binding object is truthy, so the old code returned the BINDING where
+ * callers expect the secret — no type error, just "[object Object]" wherever
+ * the value was interpolated into a header or a connection string.
+ *
+ * It never fired in production because no consumer binds Secrets Store (0 of
+ * 51 tracked wrangler configs in chittyentity at the time of writing). It
+ * fires on the first worker to adopt the documented policy, which is why it
+ * had to be fixed before any migration, not during one.
+ *
+ * On fixtures: the Secrets Store binding here is a real object with a real
+ * async get(), which is the actual runtime contract — not a mocked module.
+ * There is no way to exercise a genuine Secrets Store binding outside the
+ * Workers runtime with a provisioned store, and provisioning one requires
+ * credential access this suite does not and should not have. The shape is
+ * the contract; that is what is asserted.
+ */
+import { describe, it, expect } from "vitest";
+import { CloudflareSecretsClient } from "../../src/services/cloudflare-secrets-client.js";
+
+/** Mimics a secrets_store_secrets binding: object, async get(). */
+const storeBinding = (value) => ({ get: async () => value });
+
+describe("CloudflareSecretsClient.get — string bindings (wrangler secret put)", () => {
+  it("returns the value for a directly-named env var", async () => {
+    const c = new CloudflareSecretsClient({ NEON_DATABASE_URL: "conn-string-value" });
+    await expect(c.get("NEON_DATABASE_URL")).resolves.toBe("conn-string-value");
+  });
+
+  it("treats an empty string as absent rather than returning it", async () => {
+    // An empty secret is a misconfiguration; returning "" silently produces an
+    // unauthenticated call downstream instead of a loud failure.
+    const c = new CloudflareSecretsClient({ SOME_TOKEN: "" });
+    await expect(c.get("SOME_TOKEN")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("CloudflareSecretsClient.get — Secrets Store bindings", () => {
+  it("returns the VALUE, not the binding object — the regression", async () => {
+    const c = new CloudflareSecretsClient({ MY_SECRET: storeBinding("resolved-secret") });
+    const got = await c.get("MY_SECRET");
+    expect(got).toBe("resolved-secret");
+    expect(typeof got).toBe("string");
+  });
+
+  it("never yields something that stringifies to [object Object]", async () => {
+    // The precise production symptom the old code produced. Asserted directly
+    // because it is what a reviewer would actually have seen in a log.
+    const c = new CloudflareSecretsClient({ MY_SECRET: storeBinding("resolved-secret") });
+    const got = await c.get("MY_SECRET");
+    expect(`Bearer ${got}`).toBe("Bearer resolved-secret");
+    expect(`${got}`).not.toContain("[object Object]");
+  });
+
+  it("resolves a Secrets Store binding reached via a derived name", async () => {
+    // path -> ITEM_FIELD derivation must go through the same resolver; the old
+    // code had four independent return sites and each had the bug.
+    const c = new CloudflareSecretsClient({ MERCURY_API_TOKEN: storeBinding("mercury-value") });
+    await expect(c.get("integrations/mercury/api_token")).resolves.toBe("mercury-value");
+  });
+
+  it("treats a Secrets Store binding resolving to empty as absent", async () => {
+    const c = new CloudflareSecretsClient({ MY_SECRET: storeBinding("") });
+    await expect(c.get("MY_SECRET")).rejects.toThrow(/not found/i);
+  });
+});
+
+describe("CloudflareSecretsClient.get — mixed and missing", () => {
+  it("supports both shapes side by side during a migration", async () => {
+    // The realistic mid-migration state: some workers moved, some not.
+    const c = new CloudflareSecretsClient({
+      OLD_STYLE: "plain-string",
+      NEW_STYLE: storeBinding("store-value"),
+    });
+    await expect(c.get("OLD_STYLE")).resolves.toBe("plain-string");
+    await expect(c.get("NEW_STYLE")).resolves.toBe("store-value");
+  });
+
+  it("throws a named error when nothing matches", async () => {
+    const c = new CloudflareSecretsClient({});
+    await expect(c.get("nothing/here/at_all")).rejects.toThrow(/nothing\/here\/at_all/);
+  });
+});
+
+describe("CloudflareSecretsClient.prefetch", () => {
+  it("resolves Secrets Store bindings in bulk, skipping misses", async () => {
+    const c = new CloudflareSecretsClient({
+      A_TOKEN: storeBinding("a-value"),
+      B_TOKEN: "b-value",
+    });
+    const got = await c.prefetch(["A_TOKEN", "B_TOKEN", "MISSING_TOKEN"]);
+    expect(got.get("A_TOKEN")).toBe("a-value");
+    expect(got.get("B_TOKEN")).toBe("b-value");
+    expect(got.has("MISSING_TOKEN")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`CloudflareSecretsClient.get()` had four return sites of the form
`if (this.env[X]) return this.env[X]`. Two binding shapes land on `env`:

| Delivery | Shape |
|---|---|
| `wrangler secret put` | a plain string |
| `secrets_store_secrets` | an object with an async `.get()` |

A binding object is truthy, so every one of those lookups returned the **binding** where callers expect the secret. No type error — just `[object Object]` wherever the value was interpolated into an `Authorization` header or a connection string.

## Why it matters now

The defect never fired because nothing binds Secrets Store: **0 of 51** tracked wrangler configs in `chittyentity` have a `secrets_store_secrets` block. It fires on the first worker that adopts the documented policy — so it punished exactly the person doing the right thing, and would have read as *"Secrets Store is broken"* rather than *"the broker never supported it"*.

That is why this lands **before** any migration rather than during one.

## How

Replaced the four sites with a candidate list resolved through a single `resolveBinding()` that duck-types the async `.get()` and awaits it. Lookup order is unchanged: mapped path → literal name → `ITEM_FIELD` → `FIELD`.

Empty values are treated as absent in both shapes: an empty secret is a misconfiguration, and returning `""` silently produces an unauthenticated downstream call instead of a loud failure. `prefetch()` delegates to `get()` and is fixed transitively.

Duck-typed rather than `instanceof` because the runtime does not export the binding class. This is the same shape as `chittyentity/packages/agent-cf/src/adapters/env-secret-provider.ts`, which already had it right — the correct pattern existed in the ecosystem and had simply not reached this client.

## Validation

Tests were verified to **catch** the bug, not merely describe the fix:

- against the pre-fix file: **6 of 9 fail**
- against the fix: **9 of 9 pass**
- full `tests/services/` suite: **72 pass**

Both binding shapes are covered side by side, which is the realistic mid-migration state.

On fixtures: the Secrets Store binding in the test is a real object with a real async `get()` — that is the runtime contract. Exercising a genuinely provisioned store requires credential access a test suite should not have.

## Related

Found during a credential-plane audit following an incident in `chittyentity` (51 tracked `.env` files, since purged from history). Companion pilot — the first actual Secrets Store consumer — is `chittyentity@e72a7f2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret retrieval across plain-text and managed secret bindings.
  * Empty or unsupported bindings are now handled safely.
  * Preserved lookup order and clear missing-credential errors.
  * Maintained bulk secret prefetch and health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->