### PR TITLE
fix(secrets): one broken candidate must not hide a working one

### DIFF
--- a/src/services/cloudflare-secrets-client.js
+++ b/src/services/cloudflare-secrets-client.js
@@ -139,13 +139,29 @@ export class CloudflareSecretsClient {
       candidates.push(field.toUpperCase());
     }
 
+    // Each candidate is isolated: one broken binding must not hide a working
+    // one. Adversarial review found the unguarded form — if a Secrets Store
+    // .get() rejects (entry deleted, store unreachable), the exception escaped
+    // get() entirely and the REMAINING candidates were never tried. Mid-
+    // migration, when a mapped Secrets Store name and a literal `wrangler
+    // secret put` name both exist, a transient store failure on candidate #1
+    // took down a lookup that had a working candidate #2.
+    const attempts = [];
     for (const name of candidates) {
-      const value = await resolveBinding(this.env[name]);
-      if (value !== undefined) return value;
+      try {
+        const value = await resolveBinding(this.env[name]);
+        if (value !== undefined) return value;
+        attempts.push(`${name}: absent`);
+      } catch (err) {
+        // Record and continue. The binding NAME is safe to log; the value is
+        // never touched.
+        attempts.push(`${name}: ${err?.message ?? "resolution failed"}`);
+      }
     }
 
     throw new Error(
       `Credential not found in env bindings: ${credentialPath}. ` +
+        `Tried ${attempts.length ? attempts.join("; ") : "no candidates"}. ` +
         `Add mapping to PATH_TO_ENV or ensure secret is deployed via sync-secrets.sh`,
     );
   }

--- a/tests/services/cloudflare-secrets-client.test.js
+++ b/tests/services/cloudflare-secrets-client.test.js
@@ -102,3 +102,39 @@ describe("CloudflareSecretsClient.prefetch", () => {
     expect(got.has("MISSING_TOKEN")).toBe(false);
   });
 });
+
+describe("CloudflareSecretsClient.get — one broken candidate must not hide a working one", () => {
+  /** A binding whose .get() rejects — deleted store entry, or store unreachable. */
+  const brokenBinding = () => ({
+    get: async () => {
+      throw new Error("secrets store unavailable");
+    },
+  });
+
+  it("continues to the next candidate when the first throws", async () => {
+    // The realistic mid-migration state: a mapped Secrets Store name AND a
+    // literal `wrangler secret put` name both present. Before this fix, a
+    // transient store failure on candidate #1 escaped get() entirely and the
+    // working candidate #2 was never tried.
+    const c = new CloudflareSecretsClient({
+      MERCURY_API_TOKEN: brokenBinding(), // mapped candidate, broken
+      "integrations/mercury/api_token": "literal-fallback-value", // literal candidate, fine
+    });
+    await expect(c.get("integrations/mercury/api_token")).resolves.toBe("literal-fallback-value");
+  });
+
+  it("reports every candidate it tried when all fail", async () => {
+    const c = new CloudflareSecretsClient({ MY_SECRET: brokenBinding() });
+    // The error must name the attempts, so an operator can tell a broken
+    // binding from a missing mapping — the debugging trap the review flagged.
+    await expect(c.get("MY_SECRET")).rejects.toThrow(/Tried .*MY_SECRET/);
+    await expect(c.get("MY_SECRET")).rejects.toThrow(/secrets store unavailable/);
+  });
+
+  it("never leaks a value into the aggregate error", async () => {
+    const c = new CloudflareSecretsClient({ OTHER: "s3cr3t-should-not-appear" });
+    await expect(c.get("nothing/here/at_all")).rejects.toThrow(
+      expect.not.stringContaining("s3cr3t-should-not-appear"),
+    );
+  });
+});


### PR DESCRIPTION
Adversarial-review finding on `52433d5`.

`get()` resolves a candidate list through `resolveBinding`, which awaits a Secrets Store binding's `.get()`. **That await had no guard** — if the store entry is deleted or the store is unreachable, the rejection escaped `get()` entirely and the remaining candidates were never tried.

Mid-migration is exactly when this bites, because that's when both binding shapes coexist. `PATH_TO_ENV` maps `integrations/mercury/api_token` → `MERCURY_API_TOKEN`; if that Secrets Store binding breaks while a literal `wrangler secret put` value sits as candidate #2, a transient store failure took down a lookup that had a working fallback right behind it.

Each candidate is now isolated. Failures are recorded and the loop continues; if all fail, the error names what was attempted and why — so a broken binding is distinguishable from a missing mapping. Previously the raw store message replaced the *"Add mapping to PATH_TO_ENV"* guidance entirely.

Only binding **names** are recorded; a test asserts the aggregate error cannot contain a value.

**Verified to catch the bug:** 2 of 12 fail against the pre-fix file, 12 pass after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential retrieval when a configured secret binding is unavailable or fails.
  * The system now continues checking alternative bindings instead of stopping at the first failure.
  * Error messages provide clearer details about attempted sources without exposing secret values.

* **Tests**
  * Added coverage for fallback behavior and safe error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->