### PR TITLE
Restore credential provisioning severed by the 1Password retirement

### DIFF
--- a/src/lib/credential-broker.js
+++ b/src/lib/credential-broker.js
@@ -55,6 +55,34 @@ export function createCredentialBroker(env) {
 
 // ─── Cloudflare Secrets Broker (Default — Portal Pattern) ────────────────────
 
+
+/**
+ * Adapter for the 1Password-shaped call signature the provisioner still uses.
+ *
+ * The 1Password retirement repointed `EnhancedCredentialProvisioner.onePassword`
+ * at the broker ("Keep .onePassword as alias for backward compat"), but only
+ * OnePasswordConnectClient ever implemented getInfrastructureCredential(). Every
+ * broker class exposes get(path) instead, so with the production setting
+ * CREDENTIAL_BROKER_TYPE="cloudflare-secrets" the provisioner threw TypeError at
+ * call time — silently, because nothing exercises it until a token mint is
+ * attempted. That severed Cloudflare API-token minting, which is the sanctioned
+ * path for issuing scoped tokens.
+ *
+ * Path convention is the existing one in cloudflare-secrets-client.js PATH_TO_ENV:
+ *   infrastructure/{service}/{field}
+ */
+function attachInfrastructureCredentialAdapter(cls) {
+  cls.prototype.getInfrastructureCredential = async function (service, field, options = {}) {
+    if (!service || !field) {
+      throw new Error(
+        `E_CREDENTIAL_BAD_REF: getInfrastructureCredential requires (service, field); got (${service}, ${field})`,
+      );
+    }
+    const path = `infrastructure/${service}/${field}`;
+    return this.get(path, options);
+  };
+}
+
 class CloudflareSecretsBroker {
   constructor(env) {
     this.client = new CloudflareSecretsClient(env);
@@ -195,3 +223,10 @@ class AutoBroker {
     };
   }
 }
+
+// Every broker speaks the provisioner's legacy call shape.
+attachInfrastructureCredentialAdapter(CloudflareSecretsBroker);
+attachInfrastructureCredentialAdapter(ChittyServBroker);
+attachInfrastructureCredentialAdapter(OnePasswordBroker);
+attachInfrastructureCredentialAdapter(AutoBroker);
+

--- a/tests/credential-broker-infrastructure-adapter.test.js
+++ b/tests/credential-broker-infrastructure-adapter.test.js
@@ -1,0 +1,59 @@
+// Regression: every credential broker must answer the provisioner's legacy
+// getInfrastructureCredential(service, field) call shape.
+//
+// The 1Password retirement repointed EnhancedCredentialProvisioner.onePassword at
+// the broker, but only OnePasswordConnectClient implemented that method. With the
+// production setting CREDENTIAL_BROKER_TYPE="cloudflare-secrets" the provisioner
+// threw TypeError at call time — and only at call time, since nothing exercises
+// it until a Cloudflare API token mint is attempted. That silently severed the
+// sanctioned path for minting scoped tokens, which is why the estate kept falling
+// back to the account Global API Key.
+//
+// Real env bindings, no mocked broker: the CloudflareSecretsBroker reads from
+// env, so a plain object with the mapped binding IS the real backend here.
+
+import { describe, it, expect } from 'vitest';
+import { createCredentialBroker } from '../src/lib/credential-broker.js';
+
+const CF_ENV = {
+  CREDENTIAL_BROKER_TYPE: 'cloudflare-secrets',
+  // PATH_TO_ENV maps infrastructure/cloudflare/make_api_key -> CLOUDFLARE_MAKE_API_KEY
+  CLOUDFLARE_MAKE_API_KEY: 'test-binding-value-not-a-real-credential',
+};
+
+describe('getInfrastructureCredential adapter', () => {
+  it('exists on the broker the production config actually selects', () => {
+    const broker = createCredentialBroker(CF_ENV);
+    expect(broker.type).toBe('cloudflare-secrets');
+    expect(typeof broker.getInfrastructureCredential).toBe('function');
+  });
+
+  it('resolves (service, field) through the documented path convention', async () => {
+    const broker = createCredentialBroker(CF_ENV);
+    const value = await broker.getInfrastructureCredential('cloudflare', 'make_api_key', {
+      service: 'chittyconnect',
+      purpose: 'credential_provisioning',
+    });
+    expect(value).toBe(CF_ENV.CLOUDFLARE_MAKE_API_KEY);
+  });
+
+  it('rejects a malformed reference instead of building "infrastructure/undefined/undefined"', async () => {
+    const broker = createCredentialBroker(CF_ENV);
+    await expect(broker.getInfrastructureCredential(undefined, 'field')).rejects.toThrow(
+      /E_CREDENTIAL_BAD_REF/,
+    );
+    await expect(broker.getInfrastructureCredential('cloudflare')).rejects.toThrow(
+      /E_CREDENTIAL_BAD_REF/,
+    );
+  });
+
+  it('an unmapped path fails loudly rather than returning undefined', async () => {
+    const broker = createCredentialBroker(CF_ENV);
+    // infrastructure/github/* has no PATH_TO_ENV entry — a separate, real gap.
+    // It must surface as an error, not a silent undefined that a caller then
+    // sends to the Cloudflare API as an empty bearer token.
+    await expect(
+      broker.getInfrastructureCredential('github', 'app_id'),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## The break

Cloudflare API-token minting — the sanctioned way to issue scoped tokens — has been dead since the 1Password retirement, and it failed **silently**.

`EnhancedCredentialProvisioner` line 29:

```js
this.broker = createCredentialBroker(env);
// Keep .onePassword as alias for backward compat in internal methods
this.onePassword = this.broker;
```

The field was repointed. The **call shape** was not. Five call sites still invoke `getInfrastructureCredential(service, field, opts)` — a method only `OnePasswordConnectClient` ever implemented. Every class in `credential-broker.js` exposes `get(path)` instead.

Production runs `CREDENTIAL_BROKER_TYPE: "cloudflare-secrets"` (`wrangler.jsonc` 119/230/358) → `CloudflareSecretsBroker`, which has no such method. So the provisioner throws `TypeError` — **and only at call time**, because nothing exercises it until someone attempts a mint. `POST /api/credentials/provision` is deployed and returns 401 unauthenticated, so the route looks healthy from outside while the code behind it cannot run.

## Why this matters beyond one function

With the sanctioned minting path dead, consumers fell back to the account **Global API Key**. Measured, de-duplicated, excluding `node_modules` and worktree copies: **34 distinct first-party files** use `X-Auth-Email`/`X-Auth-Key`, including deployed workers —

- `chittyagent-cloudflare/src/index.ts`
- `chittyagent-builder/src/lib/cf-portal.ts`
- `chittyagent-mcp-builder/src/lib/cf-portal.ts`

Unscoped, non-expiring, account-wide credentials, spread by a silent break rather than by carelessness. Restoring minting is the precondition for retiring them.

## The fix

Attach a `getInfrastructureCredential(service, field, options)` adapter to all four broker classes, mapping onto the convention already used by `cloudflare-secrets-client.js` `PATH_TO_ENV`:

```
infrastructure/{service}/{field}
```

`infrastructure/cloudflare/make_api_key` → `CLOUDFLARE_MAKE_API_KEY` is already mapped, and that binding is present in production Secrets Store.

## Deliberately not done

- **No invented `infrastructure/github/*` mapping.** It genuinely doesn't exist, so GitHub App provisioning has a separate real gap. A test asserts an unmapped path **throws** — an `undefined` bearer token sent to the Cloudflare API is worse than a failed call.
- **No rotation.** `GET /accounts/0bc21e3a…/access/service_tokens` → `count:0`, so the exposed service-token pair isn't in this account under this scope. The rotation target is unidentified; any plan would be fiction until that's resolved.
- **The `/user/tokens*` vs `/accounts/{id}/tokens*` mismatch is left alone.** The provisioner targets the user-token family while the available token is account-scoped. Worth noting: `/user/tokens/verify` → 401/1000 is *expected* for an account token and was previously misdiagnosed as "invalid API token". `/accounts/{id}/tokens/verify` → **200, valid**. Pointing the code at the account family is a follow-up, not guessed at here.

## Verification

- 4 new tests, verified to **fail without the adapter** and pass with it
- Full suite: **500 passed / 1 skipped / 0 failed**
- Real env bindings, no mocked broker — `CloudflareSecretsBroker` reads from `env`, so a plain object with the mapped binding *is* the real backend

Related: chittyos/chittyconnect#279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized way to retrieve infrastructure credentials across credential brokers.
  * Infrastructure credential requests now follow a consistent service-and-field path format.
  * Invalid credential references return a clear validation error.
* **Bug Fixes**
  * Unmapped infrastructure credential paths now fail explicitly instead of returning empty results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->